### PR TITLE
plonk: multiprover: proof-system: Impl helper methods for `MpcPlonkCircuit`

### DIFF
--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -12,9 +12,7 @@ rust-version = { workspace = true }
 [dependencies]
 ark-ec = "0.4.0"
 ark-ff = { version = "0.4.0", features = ["asm"] }
-ark-mpc = { git = "https://github.com/renegade-fi/ark-mpc.git", branch = "joey/polynomials", features = [
-    "poly",
-] }
+ark-mpc = { git = "https://github.com/renegade-fi/ark-mpc.git" }
 ark-poly = "0.4.2"
 ark-serialize = "0.4.0"
 ark-std = { version = "0.4.0", default-features = false }

--- a/plonk/src/multiprover/proof_system/constraint_system.rs
+++ b/plonk/src/multiprover/proof_system/constraint_system.rs
@@ -3,10 +3,24 @@
 
 use ark_ec::CurveGroup;
 use ark_ff::FftField;
-use ark_mpc::algebra::{AuthenticatedDensePoly, AuthenticatedScalarResult};
-use ark_poly::univariate::DensePolynomial;
+use ark_mpc::{
+    algebra::{AuthenticatedDensePoly, AuthenticatedScalarResult, Scalar, ScalarResult},
+    MpcFabric,
+};
+use ark_poly::{univariate::DensePolynomial, EvaluationDomain, Radix2EvaluationDomain};
+use itertools::Itertools;
+use jf_relation::{
+    constants::{GATE_WIDTH, N_MUL_SELECTORS},
+    errors::CircuitError,
+    gates::{Gate, IoGate, PaddingGate},
+    GateId, Variable, WireId,
+};
 
 use super::MpcCircuitError;
+
+// --------------------
+// | Traits and Types |
+// --------------------
 
 /// The variable type in an MPC constraint system
 ///
@@ -41,7 +55,7 @@ pub trait MpcCircuit<C: CurveGroup> {
     fn num_gates(&self) -> usize;
 
     /// The number of variables
-    fn num_variables(&self) -> usize;
+    fn num_vars(&self) -> usize;
 
     /// The number of public inputs
     fn num_inputs(&self) -> usize;
@@ -65,10 +79,7 @@ pub trait MpcCircuit<C: CurveGroup> {
 
     /// Create a constant variable in the circuit, returning the index of the
     /// variable
-    fn create_constant_variable(
-        &mut self,
-        val: AuthenticatedScalarResult<C>,
-    ) -> Result<MpcVariable, MpcCircuitError>;
+    fn create_constant_variable(&mut self, val: Scalar<C>) -> Result<MpcVariable, MpcCircuitError>;
 
     /// Add a variable to the circuit; returns the index of the variable
     fn create_variable(
@@ -129,7 +140,7 @@ pub trait MpcCircuit<C: CurveGroup> {
     fn enforce_constant(
         &mut self,
         var: MpcVariable,
-        constant: AuthenticatedScalarResult<C>,
+        constant: Scalar<C>,
     ) -> Result<(), MpcCircuitError>;
 
     /// Constrain variable `c` to the addition of `a` and `b`.
@@ -228,4 +239,519 @@ where
     /// Return an error if the circuit has not been finalized yet.
     /// The IO gates of the circuit are guaranteed to be in the front.
     fn compute_pub_input_polynomial(&self) -> Result<AuthenticatedDensePoly<C>, MpcCircuitError>;
+}
+
+// --------------------------------
+// | Plonk Circuit Implementation |
+// --------------------------------
+
+/// A Plonk circuit instantiated over an MPC fabric
+///
+/// Largely borrowed from the single-prover implementation with modification of
+/// the field to be a secret shared analog
+#[derive(Clone)]
+/// TODO: Remove this lint allowance
+#[allow(unused)]
+pub struct MpcPlonkCircuit<C: CurveGroup>
+where
+    C::ScalarField: FftField,
+{
+    /// The number of variables
+    num_vars: usize,
+
+    /// The gate of each constraint
+    gates: Vec<Box<dyn Gate<C::ScalarField>>>,
+    /// The map from arithmetic gate wires to variables
+    wire_variables: [Vec<MpcVariable>; GATE_WIDTH + 2],
+    /// The IO gates for the list of public input variables
+    pub_input_gate_ids: Vec<GateId>,
+    /// The assignment of the witness variables
+    witness: Vec<AuthenticatedScalarResult<C>>,
+
+    /// The permutation over wires.
+    /// Each algebraic gate has 5 wires, i.e., 4 input wires and an output
+    /// wire; each lookup gate has a single wire that maps to a witness to
+    /// be checked over the lookup table. In total there are 6 * n wires
+    /// where n is the (padded) number of arithmetic/lookup gates.  
+    /// We build a permutation over the set of wires so that each set of wires
+    /// that map to the same witness forms a cycle.
+    ///
+    /// Each wire is represented by a pair (`WireId, GateId`) so that the wire
+    /// is in the `GateId`-th arithmetic/lookup gate and `WireId` represents
+    /// the wire type (e.g., 0 represents 1st input wires, 4 represents
+    /// output wires, and 5 represents lookup wires).
+    wire_permutation: Vec<(WireId, GateId)>,
+    /// The extended identity permutation.
+    extended_id_permutation: Vec<C::ScalarField>,
+    /// The number of wire types. 5 for TurboPlonk and 6 for UltraPlonk.
+    num_wire_types: usize,
+
+    /// The evaluation domain for arithmetization of the circuit into various
+    /// polynomials. This is only relevant after the circuit is finalized for
+    /// arithmetization, by default it is a domain with size 1 (only with
+    /// element 0).
+    eval_domain: Radix2EvaluationDomain<C::ScalarField>,
+
+    /// The underlying MPC fabric that this circuit is allocated within
+    fabric: MpcFabric<C>,
+}
+
+impl<C: CurveGroup> MpcPlonkCircuit<C>
+where
+    C::ScalarField: FftField,
+{
+    /// Constructor
+    pub fn new(fabric: MpcFabric<C>) -> Self {
+        let zero = fabric.zero_authenticated();
+        let one = fabric.one_authenticated();
+
+        // First build the circuit
+        let mut circuit = Self {
+            num_vars: 2,
+            witness: vec![zero, one],
+            gates: vec![],
+            wire_variables: [vec![], vec![], vec![], vec![], vec![], vec![]],
+            pub_input_gate_ids: vec![],
+
+            wire_permutation: vec![],
+            extended_id_permutation: vec![],
+            num_wire_types: GATE_WIDTH + 1,
+
+            // This is later updated
+            eval_domain: Radix2EvaluationDomain::new(1 /* num_coeffs */).unwrap(),
+            fabric,
+        };
+
+        circuit.enforce_constant(0, Scalar::zero()).unwrap();
+        circuit.enforce_constant(1, Scalar::one()).unwrap();
+
+        circuit
+    }
+}
+
+/// Private helper methods
+impl<C: CurveGroup> MpcPlonkCircuit<C> {
+    /// Whether the circuit is finalized
+    fn is_finalized(&self) -> bool {
+        self.eval_domain.size() != 1
+    }
+
+    /// Re-arrange the order of the gates so that IO (public input) gates are at
+    /// the front
+    fn rearrange_gates(&mut self) -> Result<(), MpcCircuitError> {
+        self.check_finalize_flag(true)?;
+        for (gate_id, io_gate_id) in self.pub_input_gate_ids.iter_mut().enumerate() {
+            if *io_gate_id > gate_id {
+                // Swap gate types
+                self.gates.swap(gate_id, *io_gate_id);
+
+                // Swap wire variables
+                for i in 0..GATE_WIDTH + 1 {
+                    self.wire_variables[i].swap(gate_id, *io_gate_id);
+                }
+
+                // Update io gate index
+                *io_gate_id = gate_id;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Use downcast to check whether a gate is of IoGate type
+    fn is_io_gate(&self, gate_id: GateId) -> bool {
+        self.gates[gate_id].as_any().is::<IoGate>()
+    }
+
+    /// Pad a finalized circuit to match the evaluation domain, prepared for
+    /// arithmetization
+    ///
+    /// This is a pad to a power of two
+    fn pad(&mut self) -> Result<(), MpcCircuitError> {
+        self.check_finalize_flag(true)?;
+        let n = self.eval_domain.size();
+        for _ in self.num_gates()..n {
+            self.gates.push(Box::new(PaddingGate));
+        }
+        for wire_id in 0..self.num_wire_types() {
+            self.wire_variables[wire_id].resize(n, self.zero());
+        }
+        Ok(())
+    }
+
+    /// Check that the `gate_id`-th gate is satisfied by the circuit's witness
+    /// and the public input value `pub_input`. `gate_id` is guaranteed to
+    /// be in the range. The gate equation:
+    /// qo * wo = pub_input + q_c +
+    ///           q_mul0 * w0 * w1 + q_mul1 * w2 * w3 +
+    ///           q_lc0 * w0 + q_lc1 * w1 + q_lc2 * w2 + q_lc3 * w3 +
+    ///           q_hash0 * w0 + q_hash1 * w1 + q_hash2 * w2 + q_hash3 * w3 +
+    ///           q_ecc * w0 * w1 * w2 * w3 * wo
+    ///
+    /// Returns the result of the gate minus the expected result. I.e. the gate
+    /// is correctly computed if the result is zero.
+    ///
+    /// Note: This method opens the values of the witness to check
+    /// satisfiability, it should only be used for testing
+    #[cfg(feature = "test_apis")]
+    fn check_gate(
+        &self,
+        gate_id: Variable,
+        pub_input: &AuthenticatedScalarResult<C>,
+    ) -> ScalarResult<C> {
+        // Compute wire values
+        let w_vals = (0..=GATE_WIDTH)
+            .map(|i| &self.witness[self.wire_variables[i][gate_id]])
+            .collect_vec();
+
+        // Compute selector values
+        macro_rules! as_scalars {
+            ($x:expr) => {
+                $x.iter().map(|x| Scalar::new(*x)).collect_vec()
+            };
+        }
+        let q_lc = as_scalars!(self.gates[gate_id].q_lc());
+        let q_mul = as_scalars!(self.gates[gate_id].q_mul());
+        let q_hash = as_scalars!(self.gates[gate_id].q_hash());
+        let q_c = Scalar::new(self.gates[gate_id].q_c());
+        let q_o = Scalar::new(self.gates[gate_id].q_o());
+        let q_ecc = Scalar::new(self.gates[gate_id].q_ecc());
+
+        // Compute the gate output
+        let expected_gate_output =
+            pub_input + self.compute_gate_output(q_lc, q_mul, q_hash, q_ecc, q_c, q_o, &w_vals);
+        let gate_output = q_o * w_vals[4];
+
+        (gate_output - expected_gate_output).open()
+    }
+
+    /// Compute the output of a gate given its selectors and wire values
+    ///
+    /// This method differs from the single prover case because multiplication
+    /// induces a significantly higher overhead. So we only compute the
+    /// output of a gate if its selector is non-zero
+    fn compute_gate_output(
+        &self,
+        q_lc: Vec<Scalar<C>>,
+        q_mul: Vec<Scalar<C>>,
+        q_hash: Vec<Scalar<C>>,
+        q_ecc: Scalar<C>,
+        q_c: Scalar<C>,
+        q_o: Scalar<C>,
+        wire_values: &[&AuthenticatedScalarResult<C>],
+    ) -> AuthenticatedScalarResult<C> {
+        let mut res = self.fabric.zero_authenticated();
+
+        // Macro that adds a term to the result only if its selector is non-zero
+        macro_rules! mask_selector {
+            ($sel:expr, $x:expr) => {
+                if $sel != Scalar::zero() {
+                    res = res + $x;
+                }
+            };
+        }
+
+        mask_selector!(q_lc[0], wire_values[0]);
+        mask_selector!(q_lc[1], wire_values[1]);
+        mask_selector!(q_lc[2], wire_values[2]);
+        mask_selector!(q_lc[3], wire_values[3]);
+        mask_selector!(q_mul[0], wire_values[0] * wire_values[1]);
+        mask_selector!(q_mul[1], wire_values[2] * wire_values[3]);
+        mask_selector!(
+            q_ecc,
+            wire_values[0] * wire_values[1] * wire_values[2] * wire_values[3] * wire_values[4]
+        );
+        mask_selector!(q_hash[0], wire_values[0].pow(5));
+        mask_selector!(q_hash[1], wire_values[1].pow(5));
+        mask_selector!(q_hash[2], wire_values[2].pow(5));
+        mask_selector!(q_hash[3], wire_values[3].pow(5));
+        res = res + q_c;
+
+        res
+    }
+
+    // Compute the permutation over wires.
+    // The circuit is guaranteed to be padded before calling the method.
+    #[inline]
+    fn compute_wire_permutation(&mut self) {
+        assert!(self.is_finalized());
+        let n = self.eval_domain.size();
+        let m = self.num_vars();
+
+        // Compute the mapping from variables to wires.
+        let mut variable_wires_map = vec![vec![]; m];
+        for (gate_wire_id, variables) in self
+            .wire_variables
+            .iter()
+            .take(self.num_wire_types())
+            .enumerate()
+        {
+            for (gate_id, &var) in variables.iter().enumerate() {
+                variable_wires_map[var].push((gate_wire_id, gate_id));
+            }
+        }
+
+        // Compute the wire permutation
+        self.wire_permutation = vec![(0usize, 0usize); self.num_wire_types * n];
+        for wires_vec in variable_wires_map.iter_mut() {
+            // The list of wires that map to the same variable forms a cycle.
+            if !wires_vec.is_empty() {
+                // Push the first item so that window iterator will visit the last item
+                // paired with the first item, forming a cycle
+                wires_vec.push(wires_vec[0]);
+                for window in wires_vec.windows(2) {
+                    self.wire_permutation[window[0].0 * n + window[0].1] = window[1];
+                }
+
+                // Remove the extra first item pushed at the beginning of the iterator
+                wires_vec.pop();
+            }
+        }
+    }
+
+    // Check whether the circuit is finalized. Return an error if the finalizing
+    // status is different from the expected status.
+    #[inline]
+    fn check_finalize_flag(&self, expect_finalized: bool) -> Result<(), MpcCircuitError> {
+        if !self.is_finalized() && expect_finalized {
+            return Err(MpcCircuitError::ConstraintSystem(
+                CircuitError::UnfinalizedCircuit,
+            ));
+        }
+        if self.is_finalized() && !expect_finalized {
+            return Err(MpcCircuitError::ConstraintSystem(
+                CircuitError::ModifyFinalizedCircuit,
+            ));
+        }
+        Ok(())
+    }
+
+    // Return the variable that maps to a wire `(i, j)` where i is the wire type and
+    // j is the gate index. If gate `j` is a padded dummy gate, return zero
+    // variable.
+    #[inline]
+    fn wire_variable(&self, i: WireId, j: GateId) -> Variable {
+        match j < self.wire_variables[i].len() {
+            true => self.wire_variables[i][j],
+            false => self.zero(),
+        }
+    }
+
+    // Getter for all linear combination selector
+    #[inline]
+    fn q_lc(&self) -> [Vec<C::ScalarField>; GATE_WIDTH] {
+        let mut result = [vec![], vec![], vec![], vec![]];
+        for gate in &self.gates {
+            let q_lc_vec = gate.q_lc();
+            result[0].push(q_lc_vec[0]);
+            result[1].push(q_lc_vec[1]);
+            result[2].push(q_lc_vec[2]);
+            result[3].push(q_lc_vec[3]);
+        }
+        result
+    }
+
+    // Getter for all multiplication selector
+    #[inline]
+    fn q_mul(&self) -> [Vec<C::ScalarField>; N_MUL_SELECTORS] {
+        let mut result = [vec![], vec![]];
+        for gate in &self.gates {
+            let q_mul_vec = gate.q_mul();
+            result[0].push(q_mul_vec[0]);
+            result[1].push(q_mul_vec[1]);
+        }
+        result
+    }
+
+    // Getter for all hash selector
+    #[inline]
+    fn q_hash(&self) -> [Vec<C::ScalarField>; GATE_WIDTH] {
+        let mut result = [vec![], vec![], vec![], vec![]];
+        for gate in &self.gates {
+            let q_hash_vec = gate.q_hash();
+            result[0].push(q_hash_vec[0]);
+            result[1].push(q_hash_vec[1]);
+            result[2].push(q_hash_vec[2]);
+            result[3].push(q_hash_vec[3]);
+        }
+        result
+    }
+
+    // Getter for all output selector
+    #[inline]
+    fn q_o(&self) -> Vec<C::ScalarField> {
+        self.gates.iter().map(|g| g.q_o()).collect()
+    }
+
+    // Getter for all constant selector
+    #[inline]
+    fn q_c(&self) -> Vec<C::ScalarField> {
+        self.gates.iter().map(|g| g.q_c()).collect()
+    }
+
+    // Getter for all ecc selector
+    #[inline]
+    fn q_ecc(&self) -> Vec<C::ScalarField> {
+        self.gates.iter().map(|g| g.q_ecc()).collect()
+    }
+
+    // Getter for all selectors in the following order:
+    // q_lc, q_mul, q_hash, q_o, q_c, q_ecc, [q_lookup (if support lookup)]
+    #[inline]
+    fn all_selectors(&self) -> Vec<Vec<C::ScalarField>> {
+        let mut selectors = vec![];
+        self.q_lc()
+            .as_ref()
+            .iter()
+            .chain(self.q_mul().as_ref().iter())
+            .chain(self.q_hash().as_ref().iter())
+            .for_each(|s| selectors.push(s.clone()));
+        selectors.push(self.q_o());
+        selectors.push(self.q_c());
+        selectors.push(self.q_ecc());
+
+        selectors
+    }
+}
+
+impl<C: CurveGroup> MpcCircuit<C> for MpcPlonkCircuit<C> {
+    fn num_gates(&self) -> usize {
+        self.gates.len()
+    }
+
+    fn num_vars(&self) -> usize {
+        self.num_vars
+    }
+    fn num_inputs(&self) -> usize {
+        self.pub_input_gate_ids.len()
+    }
+
+    fn num_wire_types(&self) -> usize {
+        self.num_wire_types
+    }
+
+    fn public_input(&self) -> Result<Vec<AuthenticatedScalarResult<C>>, MpcCircuitError> {
+        self.pub_input_gate_ids
+            .iter()
+            .map(|&gate_id| {
+                let var = self.wire_variables[GATE_WIDTH][gate_id];
+                self.witness(var)
+            })
+            .collect::<Result<Vec<_>, MpcCircuitError>>()
+    }
+
+    // Note: This method involves opening the witness values, it should only be
+    // used in testing contexts
+    #[cfg(feature = "test_apis")]
+    fn check_circuit_satisfiability(
+        &self,
+        public_input: &[AuthenticatedScalarResult<C>],
+    ) -> Result<(), MpcCircuitError> {
+        unimplemented!()
+    }
+
+    #[cfg(not(feature = "test_apis"))]
+    fn check_circuit_satisfiability(
+        &self,
+        public_input: &[AuthenticatedScalarResult<C>],
+    ) -> Result<(), MpcCircuitError> {
+        panic("`check_circuit_satisfiability` should not be called outside of tests, this method leaks privacy")
+    }
+
+    fn create_constant_variable(&mut self, val: Scalar<C>) -> Result<MpcVariable, MpcCircuitError> {
+        let authenticated_val = self.fabric.one_authenticated() * &val;
+        let var = self.create_variable(authenticated_val)?;
+        self.enforce_constant(var, val)?;
+
+        Ok(var)
+    }
+
+    fn create_variable(
+        &mut self,
+        val: AuthenticatedScalarResult<C>,
+    ) -> Result<MpcVariable, MpcCircuitError> {
+        unimplemented!()
+    }
+
+    fn create_public_variable(
+        &mut self,
+        val: AuthenticatedScalarResult<C>,
+    ) -> Result<MpcVariable, MpcCircuitError> {
+        unimplemented!()
+    }
+
+    fn set_variable_public(&mut self, var: MpcVariable) -> Result<(), MpcCircuitError> {
+        unimplemented!()
+    }
+
+    fn zero(&self) -> MpcVariable {
+        0
+    }
+
+    fn one(&self) -> MpcVariable {
+        1
+    }
+
+    fn witness(&self, idx: MpcVariable) -> Result<AuthenticatedScalarResult<C>, MpcCircuitError> {
+        unimplemented!()
+    }
+
+    fn enforce_constant(
+        &mut self,
+        var: MpcVariable,
+        constant: Scalar<C>,
+    ) -> Result<(), MpcCircuitError> {
+        unimplemented!()
+    }
+
+    fn add_gate(
+        &mut self,
+        a: MpcVariable,
+        b: MpcVariable,
+        c: MpcVariable,
+    ) -> Result<(), MpcCircuitError> {
+        unimplemented!()
+    }
+
+    fn add(&mut self, a: MpcVariable, b: MpcVariable) -> Result<MpcVariable, MpcCircuitError> {
+        unimplemented!()
+    }
+
+    fn sub_gate(
+        &mut self,
+        a: MpcVariable,
+        b: MpcVariable,
+        c: MpcVariable,
+    ) -> Result<(), MpcCircuitError> {
+        unimplemented!()
+    }
+
+    fn sub(&mut self, a: MpcVariable, b: MpcVariable) -> Result<MpcVariable, MpcCircuitError> {
+        unimplemented!()
+    }
+
+    fn mul_gate(
+        &mut self,
+        a: MpcVariable,
+        b: MpcVariable,
+        c: MpcVariable,
+    ) -> Result<(), MpcCircuitError> {
+        unimplemented!()
+    }
+
+    fn mul(&mut self, a: MpcVariable, b: MpcVariable) -> Result<MpcVariable, MpcCircuitError> {
+        unimplemented!()
+    }
+
+    fn enforce_bool(&mut self, a: MpcVariable) -> Result<(), MpcCircuitError> {
+        unimplemented!()
+    }
+
+    fn enforce_equal(&mut self, a: MpcVariable, b: MpcVariable) -> Result<(), MpcCircuitError> {
+        unimplemented!()
+    }
+
+    fn pad_gates(&mut self, n: usize) {
+        unimplemented!()
+    }
 }

--- a/plonk/src/multiprover/proof_system/error.rs
+++ b/plonk/src/multiprover/proof_system/error.rs
@@ -3,9 +3,14 @@
 use core::fmt::Display;
 use std::error::Error;
 
+use jf_relation::errors::CircuitError;
+
 /// The error type emitted by MPC circuit operations
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum MpcCircuitError {}
+#[derive(Debug)]
+pub enum MpcCircuitError {
+    /// An error with the constraint system
+    ConstraintSystem(CircuitError),
+}
 
 impl Display for MpcCircuitError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {


### PR DESCRIPTION
### Purpose
This PR implements an initial set of helpers on the `MpcPlonkCircuit` that allow us to implement `MpcCircuit` and `MpcArithmetization` in a follow up. This PR is incomplete in that the methods defined here are not yet used. This will be taken care of in a follow-up PR.

Here, I aim for consistency with the [single prover implementation](https://github.com/renegade-fi/mpc-jellyfish/blob/main/relation/src/constraint_system.rs#L346)

### Testing
- Unit tests pass