### PR TITLE
plonk: multiprover: constraint-system: Implement `MpcCircuit` for `MpcPlonkCircuit`

### DIFF
--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -16,6 +16,7 @@ ark-mpc = { git = "https://github.com/renegade-fi/ark-mpc.git" }
 ark-poly = "0.4.2"
 ark-serialize = "0.4.0"
 ark-std = { version = "0.4.0", default-features = false }
+async-trait = "0.1"
 derivative = { version = "2", features = ["use_core"] }
 displaydoc = { version = "0.2.3", default-features = false }
 downcast-rs = { version = "1.2.0", default-features = false }

--- a/relation/src/gates/arithmetic.rs
+++ b/relation/src/gates/arithmetic.rs
@@ -12,7 +12,7 @@ use ark_ff::Field;
 
 /// A constant gate
 #[derive(Debug, Clone)]
-pub struct ConstantGate<F: Field>(pub(crate) F);
+pub struct ConstantGate<F: Field>(pub F);
 
 impl<F> Gate<F> for ConstantGate<F>
 where

--- a/relation/src/gates/mod.rs
+++ b/relation/src/gates/mod.rs
@@ -24,7 +24,7 @@ pub use logic::*;
 pub use lookup::*;
 
 /// Describes a gate with getter for all selectors configuration
-pub trait Gate<F: Field>: Downcast + DynClone {
+pub trait Gate<F: Field>: Downcast + DynClone + Send + Sync {
     /// Get the name of a gate.
     fn name(&self) -> &'static str;
     /// Selectors for linear combination.


### PR DESCRIPTION
### Purpose
This PR implements the `MpcCircuit` trait for the `MpcPlonkCircuit` type. This trait is the interface on which a circuit is constructed, i.e. gates added, variables allocated, etc. Effectively this trait represents the constraint system frontend.

This implementation closely mirrors the [single-prover](https://github.com/renegade-fi/mpc-jellyfish/blob/main/relation/src/constraint_system.rs#L557) implementation; with methods removed that are unneeded in our case (e.g. plookup).

### Testing
- Unit and integration tests pass