### PR TITLE
plonk: multiprover: constraint-system: Implement `MpcArithmetization` for `MpcPlonkCircuit` 

### DIFF
--- a/relation/src/constraint_system.rs
+++ b/relation/src/constraint_system.rs
@@ -1119,8 +1119,10 @@ impl<F: PrimeField> PlonkCircuit<F> {
         // Compute the extended identity permutation
         // id[i*n+j] = k[i] * g^j
         let k: Vec<F> = compute_coset_representatives(self.num_wire_types, Some(n));
+
         // Precompute domain elements
         let group_elems: Vec<F> = self.eval_domain.elements().collect();
+
         // Compute extended identity permutation
         self.extended_id_permutation = vec![F::zero(); self.num_wire_types * n];
         for (i, &coset_repr) in k.iter().enumerate() {


### PR DESCRIPTION
### Purpose
This PR implements `MpcArithmetization` for `MpcPlonkCircuit`. This trait shims between the circuit satisfaction frontend and the PIOP plonk backend by interpolating wiring, public input, and permutation polynomials for the argument of knowledge.

This is closely modeled after the [single-prover](https://github.com/renegade-fi/mpc-jellyfish/blob/main/relation/src/constraint_system.rs#L1344) implementation with modifications for MPC friendliness.

### Testing
- All unit tests pass