### PR TITLE
multiprover: primitives: mpc-transcript: Add auxiliary methods for SNARK

### DIFF
--- a/plonk/src/multiprover/primitives/multiprover_kzg.rs
+++ b/plonk/src/multiprover/primitives/multiprover_kzg.rs
@@ -11,9 +11,12 @@ use core::{
 };
 
 use ark_ec::{pairing::Pairing, AffineRepr};
-use ark_mpc::algebra::{
-    AuthenticatedDensePoly, AuthenticatedPointOpenResult, AuthenticatedPointResult,
-    AuthenticatedScalarResult, CurvePoint, DensePolynomialResult, ScalarResult,
+use ark_mpc::{
+    algebra::{
+        AuthenticatedDensePoly, AuthenticatedPointOpenResult, AuthenticatedPointResult,
+        AuthenticatedScalarResult, CurvePoint, DensePolynomialResult, ScalarResult,
+    },
+    ResultId,
 };
 use futures::{ready, Future, FutureExt};
 use jf_primitives::pcs::prelude::{
@@ -44,6 +47,14 @@ pub struct MultiproverKzgCommitment<E: Pairing> {
 pub struct MultiproverKzgCommitmentOpening<E: Pairing> {
     /// The result of opening the underlying commitment
     pub opening: AuthenticatedPointOpenResult<E::G1>,
+}
+
+impl<E: Pairing> MultiproverKzgCommitmentOpening<E> {
+    /// Get the ID of the underlying opening value as allocated in the MPC
+    /// fabric
+    pub fn id(&self) -> ResultId {
+        self.opening.value.id()
+    }
 }
 
 impl<E: Pairing> MultiproverKzgCommitment<E> {


### PR DESCRIPTION
### Purpose
This PR adds extra high level interfaces to the `MpcTranscript` that will be used by the prover. The methods added here are exactly those in the [single-prover snark](https://github.com/renegade-fi/mpc-jellyfish/blob/main/plonk/src/proof_system/snark.rs#L165) implementation.

### Testing
- Unit tests pass