### PR TITLE
multiprover: proof-system: prover: Implement Plonk collaborative prover

### DIFF
--- a/plonk/src/multiprover/primitives/mpc_transcript.rs
+++ b/plonk/src/multiprover/primitives/mpc_transcript.rs
@@ -143,7 +143,7 @@ impl<P: SWCurveConfig<BaseField = E::BaseField>, E: Pairing<G1Affine = Affine<P>
     }
 
     /// Append a proof evaluation to the transcript
-    pub fn append_proof_evaluations(&mut self, evals: MpcProofEvaluations<E::G1>) {
+    pub fn append_proof_evaluations(&mut self, evals: &MpcProofEvaluations<E::G1>) {
         let n_wire_evals = evals.wires_evals.len();
         let mut ids = evals.wires_evals.iter().map(|r| r.id()).collect_vec();
 

--- a/plonk/src/multiprover/primitives/multiprover_kzg.rs
+++ b/plonk/src/multiprover/primitives/multiprover_kzg.rs
@@ -33,7 +33,7 @@ pub struct MultiproverKZG<E: Pairing> {
 }
 
 /// A commitment to the shared polynomial
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MultiproverKzgCommitment<E: Pairing> {
     /// The underlying commitment, an element of the curve group
     pub commitment: AuthenticatedPointResult<E::G1>,
@@ -43,7 +43,7 @@ pub struct MultiproverKzgCommitment<E: Pairing> {
 ///
 /// Wrapping the type in this way allows us to implement `Future` and resolve
 /// this opening to a standard, single-prover KZG commitment
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MultiproverKzgCommitmentOpening<E: Pairing> {
     /// The result of opening the underlying commitment
     pub opening: AuthenticatedPointOpenResult<E::G1>,

--- a/plonk/src/multiprover/proof_system/constraint_system.rs
+++ b/plonk/src/multiprover/proof_system/constraint_system.rs
@@ -687,6 +687,7 @@ impl<C: CurveGroup> MpcCircuit<C> for MpcPlonkCircuit<C> {
     fn num_vars(&self) -> usize {
         self.num_vars
     }
+
     fn num_inputs(&self) -> usize {
         self.pub_input_gate_ids.len()
     }

--- a/plonk/src/multiprover/proof_system/snark.rs
+++ b/plonk/src/multiprover/proof_system/snark.rs
@@ -6,16 +6,185 @@
 
 use core::marker::PhantomData;
 
-use ark_ec::pairing::Pairing;
+use ark_ec::{
+    pairing::Pairing,
+    short_weierstrass::{Affine, SWCurveConfig},
+};
+use ark_mpc::{algebra::AuthenticatedScalarResult, MpcFabric};
+use ark_std::rand::{CryptoRng, RngCore};
+use itertools::Itertools;
+
+use crate::{
+    errors::{PlonkError, SnarkError},
+    multiprover::{primitives::MpcTranscript, proof_system::structs::CollaborativeProof},
+    proof_system::structs::ProvingKey,
+};
+
+use super::{MpcArithmetization, MpcChallenges, MpcOracles, MpcProver};
 
 /// A multiprover Plonk instantiated with KZG as the underlying polynomial
 /// commitment scheme
 #[derive(Default)]
 pub struct MultiproverPlonkKzgSnark<E: Pairing>(PhantomData<E>);
 
-impl<E: Pairing> MultiproverPlonkKzgSnark<E> {
+impl<P: SWCurveConfig<BaseField = E::BaseField>, E: Pairing<G1Affine = Affine<P>>>
+    MultiproverPlonkKzgSnark<E>
+{
     /// Constructor
     pub fn new() -> Self {
         Self(PhantomData)
     }
+
+    /// Create a new multiprover proof
+    pub fn prove<R, C>(
+        prng: &mut R,
+        circuit: &C,
+        proving_key: &ProvingKey<E>,
+        fabric: MpcFabric<E::G1>,
+    ) -> Result<CollaborativeProof<E>, PlonkError>
+    where
+        C: MpcArithmetization<E::G1>,
+        R: CryptoRng + RngCore,
+    {
+        let domain_size = circuit.eval_domain_size()?;
+        let num_wire_types = circuit.num_wire_types();
+        Self::validate_circuit(circuit, proving_key)?;
+
+        // Initialize the transcript
+        let mut transcript = MpcTranscript::<E>::new(b"PlonkProof", fabric.clone());
+
+        // Append the public input to the transcript
+        let input = AuthenticatedScalarResult::open_authenticated_batch(&circuit.public_input()?)
+            .into_iter()
+            .map(|r| r.value)
+            .collect_vec();
+        transcript.append_vk_and_pub_input(proving_key.vk.clone(), &input);
+
+        // Initialize verifier challenges and online polynomial oracles
+        let mut challenges = MpcChallenges::default(&fabric);
+        let mut online_oracles = MpcOracles::default();
+        let prover = MpcProver::new(domain_size, num_wire_types, fabric.clone())?;
+
+        // --- Round 1 --- //
+        let ((wires_poly_comms, wire_polys), pi_poly) =
+            prover.run_1st_round(prng, &proving_key.commit_key, circuit)?;
+
+        online_oracles.wire_polys = wire_polys;
+        online_oracles.pub_input_poly = pi_poly;
+
+        // Open the commitments and append them to the transcript
+        let wires_poly_comms_vec = wires_poly_comms
+            .iter()
+            .map(|comm| comm.open_authenticated())
+            .collect_vec();
+        transcript.append_commitments(b"witness_poly_comms", &wires_poly_comms_vec);
+
+        // Though we don't use plookup in the multiprover setting, we still squeeze a
+        // challenge to ensure that the transcript is consistent
+        transcript.get_and_append_challenge(b"tau");
+
+        // --- Round 2 --- //
+        challenges.beta = transcript.get_and_append_challenge(b"beta");
+        challenges.gamma = transcript.get_and_append_challenge(b"gamma");
+
+        let (prod_perm_poly_comm, prod_perm_poly) =
+            prover.run_2nd_round(&proving_key.commit_key, circuit, &challenges)?;
+        online_oracles.prod_perm_poly = prod_perm_poly;
+
+        let prod_perm_poly_comm_open = prod_perm_poly_comm.open_authenticated();
+        transcript.append_commitment(b"perm_poly_comms", &prod_perm_poly_comm_open);
+
+        // --- Round 3 --- //
+        challenges.alpha = transcript.get_and_append_challenge(b"alpha");
+        let (split_quot_poly_comms, split_quot_polys) = prover.run_3rd_round(
+            prng,
+            &proving_key.commit_key,
+            proving_key,
+            &challenges,
+            &online_oracles,
+            num_wire_types,
+        )?;
+
+        let split_quote_poly_comm_open = split_quot_poly_comms
+            .iter()
+            .map(|comm| comm.open_authenticated())
+            .collect_vec();
+        transcript.append_commitments(b"quot_poly_comms", &split_quote_poly_comm_open);
+
+        // --- Round 4 --- //
+        challenges.zeta = transcript.get_and_append_challenge(b"zeta");
+        let poly_evals =
+            prover.compute_evaluations(proving_key, &challenges, &online_oracles, num_wire_types);
+
+        transcript.append_proof_evaluations(&poly_evals);
+
+        // Compute the linearization polynomial
+        let mut lin_poly = prover.compute_quotient_component_for_lin_poly(
+            domain_size,
+            challenges.zeta.clone(),
+            &split_quot_polys,
+        )?;
+
+        lin_poly = lin_poly
+            + prover.compute_non_quotient_component_for_lin_poly(
+                &fabric.one(),
+                proving_key,
+                &challenges,
+                &online_oracles,
+                &poly_evals,
+            )?;
+
+        // --- Round 5 --- //
+        challenges.v = transcript.get_and_append_challenge(b"v");
+        let (opening_proof, shifted_opening_proof) = prover.compute_opening_proofs(
+            &proving_key.commit_key,
+            proving_key,
+            &challenges.zeta,
+            &challenges.v,
+            &online_oracles,
+            &lin_poly,
+        )?;
+
+        Ok(CollaborativeProof {
+            wire_poly_comms: wires_poly_comms_vec,
+            prod_perm_poly_comm: prod_perm_poly_comm_open,
+            split_quot_poly_comms: split_quote_poly_comm_open,
+            opening_proof,
+            shifted_opening_proof,
+            poly_evals,
+        })
+    }
+
+    /// Verify that the shape of the proving key and the circuit match
+    fn validate_circuit<C: MpcArithmetization<E::G1>>(
+        circuit: &C,
+        proving_key: &ProvingKey<E>,
+    ) -> Result<(), PlonkError> {
+        let n = circuit.eval_domain_size()?;
+        if proving_key.domain_size() != n {
+            return Err(SnarkError::ParameterError(format!(
+                "proving key domain size {} != expected domain size {}",
+                proving_key.domain_size(),
+                n
+            ))
+            .into());
+        }
+
+        if circuit.num_inputs() != proving_key.vk.num_inputs {
+            return Err(SnarkError::ParameterError(format!(
+                "circuit.num_inputs {} != prove_key.num_inputs {}",
+                circuit.num_inputs(),
+                proving_key.vk.num_inputs
+            ))
+            .into());
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_prove_simple_circuit() {}
 }

--- a/plonk/src/multiprover/proof_system/structs.rs
+++ b/plonk/src/multiprover/proof_system/structs.rs
@@ -1,9 +1,25 @@
 //! Generic container structs used in the proof system
-use ark_ec::CurveGroup;
-use ark_mpc::algebra::{AuthenticatedDensePoly, ScalarResult};
+use core::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use ark_ec::{pairing::Pairing, CurveGroup};
+use ark_mpc::{
+    algebra::{AuthenticatedDensePoly, Scalar, ScalarResult},
+    MpcFabric,
+};
+use futures::{ready, Future};
+use itertools::Itertools;
+
+use crate::{
+    errors::PlonkError,
+    multiprover::primitives::{MultiproverKzgCommitment, MultiproverKzgCommitmentOpening},
+    proof_system::structs::{Proof, ProofEvaluations},
+};
 
 /// Multiprover Plonk IOP online polynomial oracles
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct MpcOracles<C: CurveGroup> {
     pub(crate) wire_polys: Vec<AuthenticatedDensePoly<C>>,
     pub(crate) pub_input_poly: AuthenticatedDensePoly<C>,
@@ -29,6 +45,20 @@ pub struct MpcChallenges<C: CurveGroup> {
     pub v: ScalarResult<C>,
 }
 
+impl<C: CurveGroup> MpcChallenges<C> {
+    /// A custom default implementation that sets all challenges to zero
+    /// initially
+    pub fn default(fabric: &MpcFabric<C>) -> Self {
+        Self {
+            alpha: fabric.zero(),
+            beta: fabric.zero(),
+            gamma: fabric.zero(),
+            zeta: fabric.zero(),
+            v: fabric.zero(),
+        }
+    }
+}
+
 /// A struct that stores the polynomial evaluations in a Plonk proof
 ///
 /// Note that this struct differs from the analog in the single-prover
@@ -52,4 +82,128 @@ pub struct MpcProofEvaluations<C: CurveGroup> {
 
     /// Permutation product polynomial evaluation at point `zeta * g`
     pub perm_next_eval: ScalarResult<C>,
+}
+
+/// A struct that represents a completed proof in a multiprover context
+#[derive(Debug, Clone)]
+pub struct CollaborativeProof<E: Pairing> {
+    /// The commitments to the wiring polynomials
+    pub wire_poly_comms: Vec<MultiproverKzgCommitmentOpening<E>>,
+    /// The commitment to the wire permutation polynomial
+    pub prod_perm_poly_comm: MultiproverKzgCommitmentOpening<E>,
+    /// The split quotient polynomial commitments
+    pub split_quot_poly_comms: Vec<MultiproverKzgCommitmentOpening<E>>,
+    /// The proof of evaluation of the aggregated argument at a challenge point
+    pub opening_proof: MultiproverKzgCommitment<E>,
+    /// The proof of evaluation of the aggregated argument at the challenge
+    /// point shifted by one multiplication with generator in the
+    /// root-of-unit group
+    pub shifted_opening_proof: MultiproverKzgCommitment<E>,
+    /// Polynomial evaluations of each component in the linearization polynomial
+    pub poly_evals: MpcProofEvaluations<E::G1>,
+}
+
+impl<E: Pairing> CollaborativeProof<E> {
+    /// Open the proof to both parties
+    pub fn open_authenticated(self) -> CollaborativeProofOpening<E> {
+        CollaborativeProofOpening {
+            wire_poly_comms: self.wire_poly_comms,
+            prod_perm_poly_comm: self.prod_perm_poly_comm,
+            split_quot_poly_comms: self.split_quot_poly_comms,
+            opening_proof: self.opening_proof.open_authenticated(),
+            shifted_opening_proof: self.shifted_opening_proof.open_authenticated(),
+            poly_evals: self.poly_evals,
+        }
+    }
+}
+
+/// A struct that represents a handle on a yet-to-be computed proof opening
+///
+/// This struct allows us to implement `Future` and target the `Proof` object
+/// as the resolved type
+#[derive(Debug, Clone)]
+pub struct CollaborativeProofOpening<E: Pairing> {
+    /// The commitments to the wiring polynomials
+    pub wire_poly_comms: Vec<MultiproverKzgCommitmentOpening<E>>,
+    /// The commitment to the wire permutation polynomial
+    pub prod_perm_poly_comm: MultiproverKzgCommitmentOpening<E>,
+    /// The split quotient polynomial commitments
+    pub split_quot_poly_comms: Vec<MultiproverKzgCommitmentOpening<E>>,
+    /// The proof of evaluation of the aggregated argument at a challenge point
+    pub opening_proof: MultiproverKzgCommitmentOpening<E>,
+    /// The proof of evaluation of the aggregated argument at the challenge
+    /// point shifted by one multiplication with generator in the
+    /// root-of-unit group
+    pub shifted_opening_proof: MultiproverKzgCommitmentOpening<E>,
+    /// Polynomial evaluations of each component in the linearization polynomial
+    pub poly_evals: MpcProofEvaluations<E::G1>,
+}
+
+impl<E: Pairing> Future for CollaborativeProofOpening<E>
+where
+    E::ScalarField: Unpin,
+{
+    type Output = Result<Proof<E>, PlonkError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // Poll a single future that returns `Result<T, E>`, and early exit if it
+        // resolves to an error
+        macro_rules! poll_res {
+            // Propagates errors after a future resolves
+            ($x:expr, ?) => {{
+                match poll_res!($x) {
+                    Ok(res) => res,
+                    Err(err) => return Poll::Ready(Err(err.into())),
+                }
+            }};
+
+            // Does not propagate errors
+            ($x:expr) => {{
+                ready!(Pin::new($x).poll(cx))
+            }};
+        }
+
+        // Poll a vector of futures, and optionally (with `?`) early exit if
+        // any of them resolve to an error
+        macro_rules! poll_vec {
+            ($x:expr $(, $tail:tt)?) => {{
+                let mut results = Vec::new();
+                for future in $x.iter_mut() {
+                    results.push(poll_res!(future $(, $tail)?));
+                }
+
+                results
+            }};
+        }
+
+        // Open each proof element
+        let wires_poly_comms = poll_vec!(self.wire_poly_comms, ?);
+        let prod_perm_poly_comm = poll_res!(&mut self.prod_perm_poly_comm, ?);
+        let split_quot_poly_comms = poll_vec!(self.split_quot_poly_comms, ?);
+        let opening_proof = poll_res!(&mut self.opening_proof, ?);
+        let shifted_opening_proof = poll_res!(&mut self.shifted_opening_proof, ?);
+        let wires_evals = poll_vec!(self.poly_evals.wires_evals)
+            .iter()
+            .map(Scalar::inner)
+            .collect_vec();
+        let wire_sigma_evals = poll_vec!(self.poly_evals.wire_sigma_evals)
+            .iter()
+            .map(Scalar::inner)
+            .collect_vec();
+        let perm_next_eval = poll_res!(&mut self.poly_evals.perm_next_eval).inner();
+
+        Poll::Ready(Ok(Proof {
+            wires_poly_comms,
+            prod_perm_poly_comm,
+            split_quot_poly_comms,
+            opening_proof,
+            shifted_opening_proof,
+            poly_evals: ProofEvaluations {
+                wires_evals,
+                wire_sigma_evals,
+                perm_next_eval,
+            },
+            plookup_proof: None,
+        }))
+    }
 }


### PR DESCRIPTION
### Purpose
This PR ties together the individual helper methods that implement each round in the Plonk protocol introduced in separate PRs. The implementation closely follows the [single-prover implementation](https://github.com/renegade-fi/mpc-jellyfish/blob/main/plonk/src/proof_system/snark.rs#L165) in structure.

This PR also defines the `CollaborativeProof` type and opening logic for the proof.

### Testing
- Unit tests pass
- Testing of the collaborative prover will come in a follow up PR.