### PR TITLE
multiprover: proof-system: prover: Add round 1 tests and gadgets

### DIFF
--- a/plonk/src/multiprover/gadgets/arithmetic.rs
+++ b/plonk/src/multiprover/gadgets/arithmetic.rs
@@ -1,0 +1,80 @@
+//! Defines arithmetic gadgets for use in circuits
+
+use ark_ec::CurveGroup;
+use ark_mpc::algebra::Scalar;
+use jf_relation::{
+    errors::CircuitError,
+    gates::{ConstantAdditionGate, ConstantMultiplicationGate},
+};
+
+use crate::multiprover::proof_system::{MpcCircuit, MpcPlonkCircuit, MpcVariable};
+
+impl<C: CurveGroup> MpcPlonkCircuit<C> {
+    /// Constrain variable `y` to the addition of `a` and `c`, where `c` is a
+    /// constant value Return error if the input variables are invalid.
+    pub fn add_constant_gate(
+        &mut self,
+        x: MpcVariable,
+        c: Scalar<C>,
+        y: MpcVariable,
+    ) -> Result<(), CircuitError> {
+        self.check_var_bound(x)?;
+        self.check_var_bound(y)?;
+
+        let wire_vars = &[x, self.one(), 0, 0, y];
+        self.insert_gate(wire_vars, Box::new(ConstantAdditionGate(c.inner())))?;
+        Ok(())
+    }
+
+    /// Obtains a variable representing an addition with a constant value
+    /// Return error if the input variable is invalid
+    pub fn add_constant(
+        &mut self,
+        input_var: MpcVariable,
+        elem: &Scalar<C>,
+    ) -> Result<MpcVariable, CircuitError> {
+        self.check_var_bound(input_var)?;
+
+        let input_val = self.witness(input_var).unwrap();
+        let output_val = *elem + input_val;
+        let output_var = self.create_variable(output_val).unwrap();
+
+        self.add_constant_gate(input_var, *elem, output_var)?;
+
+        Ok(output_var)
+    }
+
+    /// Constrain variable `y` to the product of `a` and `c`, where `c` is a
+    /// constant value Return error if the input variables are invalid.
+    pub fn mul_constant_gate(
+        &mut self,
+        x: MpcVariable,
+        c: Scalar<C>,
+        y: MpcVariable,
+    ) -> Result<(), CircuitError> {
+        self.check_var_bound(x)?;
+        self.check_var_bound(y)?;
+
+        let wire_vars = &[x, 0, 0, 0, y];
+        self.insert_gate(wire_vars, Box::new(ConstantMultiplicationGate(c.inner())))?;
+        Ok(())
+    }
+
+    /// Obtains a variable representing a multiplication with a constant value
+    /// Return error if the input variable is invalid
+    pub fn mul_constant(
+        &mut self,
+        input_var: MpcVariable,
+        elem: &Scalar<C>,
+    ) -> Result<MpcVariable, CircuitError> {
+        self.check_var_bound(input_var)?;
+
+        let input_val = self.witness(input_var).unwrap();
+        let output_val = *elem * input_val;
+        let output_var = self.create_variable(output_val).unwrap();
+
+        self.mul_constant_gate(input_var, *elem, output_var)?;
+
+        Ok(output_var)
+    }
+}

--- a/plonk/src/multiprover/gadgets/mod.rs
+++ b/plonk/src/multiprover/gadgets/mod.rs
@@ -1,0 +1,5 @@
+//! Defines commonly used gadgets directly on the circuit type
+//!
+//! These gadgets are largely copied from the single-prover implementation
+
+pub mod arithmetic;

--- a/plonk/src/multiprover/mod.rs
+++ b/plonk/src/multiprover/mod.rs
@@ -1,5 +1,6 @@
 //! The `multiprover` module extends the `jellyfish` plonk implementation to
 //! support collaborative proofs as examined by Ozdemir and Boneh: https://eprint.iacr.org/2021/1530
 
+pub mod gadgets;
 pub mod primitives;
 pub mod proof_system;

--- a/plonk/src/multiprover/proof_system/snark.rs
+++ b/plonk/src/multiprover/proof_system/snark.rs
@@ -67,7 +67,7 @@ impl<P: SWCurveConfig<BaseField = E::BaseField>, E: Pairing<G1Affine = Affine<P>
 
         // --- Round 1 --- //
         let ((wires_poly_comms, wire_polys), pi_poly) =
-            prover.run_1st_round(prng, &proving_key.commit_key, circuit)?;
+            prover.run_1st_round(&proving_key.commit_key, circuit)?;
 
         online_oracles.wire_polys = wire_polys;
         online_oracles.pub_input_poly = pi_poly;

--- a/relation/src/gates/arithmetic.rs
+++ b/relation/src/gates/arithmetic.rs
@@ -50,7 +50,7 @@ where
 
 /// Adding a variable by a constant.
 #[derive(Debug, Clone)]
-pub struct ConstantAdditionGate<F: Field>(pub(crate) F);
+pub struct ConstantAdditionGate<F: Field>(pub F);
 
 impl<F> Gate<F> for ConstantAdditionGate<F>
 where
@@ -111,7 +111,7 @@ where
 /// A mul constant gate.
 /// Multiply the first variable with the constant.
 #[derive(Debug, Clone)]
-pub struct ConstantMultiplicationGate<F>(pub(crate) F);
+pub struct ConstantMultiplicationGate<F>(pub F);
 
 impl<F> Gate<F> for ConstantMultiplicationGate<F>
 where


### PR DESCRIPTION
### Purpose
This PR introduces basic testing scaffolding for the Plonk multiprover. This includes:
1. Simple gadgets borrowed from the single-prover implementation [here](https://github.com/renegade-fi/mpc-jellyfish/blob/main/relation/src/gadgets/arithmetic.rs#L244). More gadgets will be added as a follow up
2. Mock random number generators: this ensures that proofs are not randomized, so individual components of the proof can be directly compared between single and multi-prover
3. A test for the first round of the Plonk protocol

### Testing
- Unit tests pass
- Tested Plonk first round