### PR TITLE
multiprover: proof-system: prover: Add 2nd round tests + bug fixes

### DIFF
--- a/plonk/src/multiprover/proof_system/constraint_system.rs
+++ b/plonk/src/multiprover/proof_system/constraint_system.rs
@@ -1079,7 +1079,8 @@ impl<C: CurveGroup> MpcArithmetization<C> for MpcPlonkCircuit<C> {
 
                 let (perm_i, perm_j) = self.wire_permutation[i * n + j];
                 b = b
-                    * (tmp + beta + Scalar::new(self.extended_id_permutation[perm_i * n + perm_j]));
+                    * (&tmp
+                        + beta * Scalar::new(self.extended_id_permutation[perm_i * n + perm_j]));
             }
 
             numerators.push(a);

--- a/plonk/src/multiprover/proof_system/snark.rs
+++ b/plonk/src/multiprover/proof_system/snark.rs
@@ -67,7 +67,7 @@ impl<P: SWCurveConfig<BaseField = E::BaseField>, E: Pairing<G1Affine = Affine<P>
 
         // --- Round 1 --- //
         let ((wires_poly_comms, wire_polys), pi_poly) =
-            prover.run_1st_round(&proving_key.commit_key, circuit)?;
+            prover.run_1st_round(&proving_key.commit_key, circuit, true /* mask */)?;
 
         online_oracles.wire_polys = wire_polys;
         online_oracles.pub_input_poly = pi_poly;
@@ -87,8 +87,12 @@ impl<P: SWCurveConfig<BaseField = E::BaseField>, E: Pairing<G1Affine = Affine<P>
         challenges.beta = transcript.get_and_append_challenge(b"beta");
         challenges.gamma = transcript.get_and_append_challenge(b"gamma");
 
-        let (prod_perm_poly_comm, prod_perm_poly) =
-            prover.run_2nd_round(&proving_key.commit_key, circuit, &challenges)?;
+        let (prod_perm_poly_comm, prod_perm_poly) = prover.run_2nd_round(
+            &proving_key.commit_key,
+            circuit,
+            &challenges,
+            true, // mask
+        )?;
         online_oracles.prod_perm_poly = prod_perm_poly;
 
         let prod_perm_poly_comm_open = prod_perm_poly_comm.open_authenticated();

--- a/plonk/src/proof_system/snark.rs
+++ b/plonk/src/proof_system/snark.rs
@@ -245,8 +245,12 @@ where
         // Round 1
         let mut wires_poly_comms_vec = vec![];
         for i in 0..circuits.len() {
-            let ((wires_poly_comms, wire_polys), pi_poly) =
-                prover.run_1st_round(prng, &prove_keys[i].commit_key, circuits[i])?;
+            let ((wires_poly_comms, wire_polys), pi_poly) = prover.run_1st_round(
+                prng,
+                &prove_keys[i].commit_key,
+                circuits[i],
+                true, // mask
+            )?;
             online_oracles[i].wire_polys = wire_polys;
             online_oracles[i].pub_inp_poly = pi_poly;
             transcript.append_commitments(b"witness_poly_comms", &wires_poly_comms)?;
@@ -268,6 +272,7 @@ where
                         &prove_keys[i].commit_key,
                         circuits[i],
                         challenges.tau,
+                        true, // mask
                     )?;
                 online_oracles[i].plookup_oracles.h_polys = h_polys;
                 transcript.append_commitments(b"h_poly_comms", &h_poly_comms)?;
@@ -285,8 +290,13 @@ where
         challenges.gamma = transcript.get_and_append_challenge::<E>(b"gamma")?;
         let mut prod_perm_poly_comms_vec = vec![];
         for i in 0..circuits.len() {
-            let (prod_perm_poly_comm, prod_perm_poly) =
-                prover.run_2nd_round(prng, &prove_keys[i].commit_key, circuits[i], &challenges)?;
+            let (prod_perm_poly_comm, prod_perm_poly) = prover.run_2nd_round(
+                prng,
+                &prove_keys[i].commit_key,
+                circuits[i],
+                &challenges,
+                true, // mask
+            )?;
             online_oracles[i].prod_perm_poly = prod_perm_poly;
             transcript.append_commitment(b"perm_poly_comms", &prod_perm_poly_comm)?;
             prod_perm_poly_comms_vec.push(prod_perm_poly_comm);
@@ -304,6 +314,7 @@ where
                     &challenges,
                     merged_table_list[i].as_ref(),
                     sorted_vec_list[i].as_ref(),
+                    true, // mask
                 )?;
                 online_oracles[i].plookup_oracles.prod_lookup_poly = prod_lookup_poly;
                 transcript.append_commitment(b"plookup_poly_comms", &prod_lookup_poly_comm)?;

--- a/plonk/src/proof_system/structs.rs
+++ b/plonk/src/proof_system/structs.rs
@@ -837,7 +837,7 @@ impl<E: Pairing> VerifyingKey<E> {
 }
 
 /// Plonk IOP verifier challenges.
-#[derive(Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Challenges<F: Field> {
     pub tau: F,
     pub alpha: F,


### PR DESCRIPTION
### Purpose
This PR adds tests and fixes bugs in the second round of the Plonk protocol. As well, this PR removes the mocked `RngCore` implementation that was previously added. Relying on zero'd randomness has issues with non-invertibility elsewhere in the MPC gadgetry, so we need true non-zero randomness. Instead we simply do not randomize the proof, and ensure that proof-randomization is not disabled outside of tests

### Testing
- Unit tests pass
- Tested the second round prover equivalence