### PR TITLE
multiprover: proof-system: prover: Add 4th/5th round tests and bug fixes

### DIFF
--- a/plonk/src/multiprover/proof_system/snark.rs
+++ b/plonk/src/multiprover/proof_system/snark.rs
@@ -121,7 +121,7 @@ impl<P: SWCurveConfig<BaseField = E::BaseField>, E: Pairing<G1Affine = Affine<P>
         // Compute the linearization polynomial
         let mut lin_poly = prover.compute_quotient_component_for_lin_poly(
             domain_size,
-            challenges.zeta.clone(),
+            &challenges.zeta,
             &split_quot_polys,
         )?;
 
@@ -132,7 +132,7 @@ impl<P: SWCurveConfig<BaseField = E::BaseField>, E: Pairing<G1Affine = Affine<P>
                 &challenges,
                 &online_oracles,
                 &poly_evals,
-            )?;
+            );
 
         // --- Round 5 --- //
         challenges.v = transcript.get_and_append_challenge(b"v");


### PR DESCRIPTION
### Purpose
This PR adds tests for the fourth and fifth rounds of the Plonk protocol. Testing follows the structure given in previous PRs.

### Testing
- Unit tests pass
- Tested 4th and 5th rounds