### PR TITLE
multiprover: proof-system: snark: Add e2e circuit prover/verifer tests

### DIFF
--- a/plonk/src/multiprover/proof_system/prover.rs
+++ b/plonk/src/multiprover/proof_system/prover.rs
@@ -807,7 +807,7 @@ pub fn mul_poly_result<C: CurveGroup>(
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
 
     use ark_ec::pairing::Pairing;
     use ark_ff::{One, Zero};
@@ -846,7 +846,7 @@ mod test {
     pub const MAX_DEGREE_TESTING: usize = 1024;
 
     /// Setup commitment keys, proving and verification keys for the snark
-    fn setup_snark<C: Arithmetization<TestScalar>>(
+    pub(crate) fn setup_snark<C: Arithmetization<TestScalar>>(
         circuit: &C,
     ) -> (ProvingKey<TestCurve>, VerifyingKey<TestCurve>) {
         let mut rng = thread_rng();
@@ -922,7 +922,9 @@ mod test {
     }
 
     /// Generate the testing circuit in a singleprover context
-    fn test_singleprover_circuit(witness: Scalar<TestGroup>) -> PlonkCircuit<TestScalar> {
+    pub(crate) fn test_singleprover_circuit(
+        witness: Scalar<TestGroup>,
+    ) -> PlonkCircuit<TestScalar> {
         let mut circuit = PlonkCircuit::new_turbo_plonk();
 
         let mut res = circuit.create_variable(witness.inner()).unwrap();
@@ -940,7 +942,7 @@ mod test {
     }
 
     /// Generate the testing circuit in a multiprover context
-    fn test_multiprover_circuit(
+    pub(crate) fn test_multiprover_circuit(
         witness: Scalar<TestGroup>,
         fabric: &MpcFabric<TestGroup>,
     ) -> MpcPlonkCircuit<TestGroup> {


### PR DESCRIPTION
### Purpose
This PR adds two tests for the end-to-end prove/verify flow in a collaborative setting. The tests are a simple circuit, used for testing individual protocol rounds, and a more complex circuit, mimicking the one used in the single-prover tests.

### Testing
- Unit tests pass