### PR TITLE
multiprover: gadgets: arithmetic: Add arithmetic gadgets from single-prover

### DIFF
--- a/plonk/src/multiprover/gadgets/arithmetic.rs
+++ b/plonk/src/multiprover/gadgets/arithmetic.rs
@@ -1,42 +1,259 @@
 //! Defines arithmetic gadgets for use in circuits
 
 use ark_ec::CurveGroup;
-use ark_mpc::algebra::Scalar;
+use ark_ff::One;
+use ark_mpc::algebra::{AuthenticatedScalarResult, Scalar};
 use jf_relation::{
+    constants::{GATE_WIDTH, N_MUL_SELECTORS},
     errors::CircuitError,
-    gates::{ConstantAdditionGate, ConstantMultiplicationGate},
+    gates::{
+        ConstantAdditionGate, ConstantMultiplicationGate, FifthRootGate, LinCombGate, MulAddGate,
+        QuadPolyGate,
+    },
+    Variable,
 };
 
-use crate::multiprover::proof_system::{MpcCircuit, MpcPlonkCircuit, MpcVariable};
+use crate::multiprover::proof_system::{MpcCircuit, MpcPlonkCircuit};
+
+use super::{next_multiple, scalar};
 
 impl<C: CurveGroup> MpcPlonkCircuit<C> {
+    /// Arithmetic gates
+    ///
+    /// Quadratic polynomial gate: q1 * a + q2 * b + q3 * c + q4 * d + q12 * a *
+    /// b + q34 * c * d + q_c = q_o * e, where q1, q2, q3, q4, q12, q34,
+    /// q_c, q_o are selectors; a, b, c, d are input wires; e is the output
+    /// wire. Return error if variables are invalid.
+    pub fn quad_poly_gate(
+        &mut self,
+        wires: &[Variable; GATE_WIDTH + 1],
+        q_lc: &[C::ScalarField; GATE_WIDTH],
+        q_mul: &[C::ScalarField; N_MUL_SELECTORS],
+        q_o: C::ScalarField,
+        q_c: C::ScalarField,
+    ) -> Result<(), CircuitError> {
+        self.check_vars_bound(wires)?;
+
+        self.insert_gate(
+            wires,
+            Box::new(QuadPolyGate {
+                q_lc: *q_lc,
+                q_mul: *q_mul,
+                q_o,
+                q_c,
+            }),
+        )?;
+        Ok(())
+    }
+
+    /// Arithmetic gates
+    ///
+    /// Quadratic polynomial gate:
+    /// e = q1 * a + q2 * b + q3 * c + q4 * d + q12 * a *
+    /// b + q34 * c * d + q_c, where q1, q2, q3, q4, q12, q34,
+    /// q_c are selectors; a, b, c, d are input wires
+    ///
+    /// Return the variable for
+    /// Return error if variables are invalid.
+    pub fn gen_quad_poly(
+        &mut self,
+        wires: &[Variable; GATE_WIDTH],
+        q_lc: &[C::ScalarField; GATE_WIDTH],
+        q_mul: &[C::ScalarField; N_MUL_SELECTORS],
+        q_c: C::ScalarField,
+    ) -> Result<Variable, CircuitError> {
+        self.check_vars_bound(wires)?;
+        let output_val = scalar!(q_lc[0]) * self.witness(wires[0])?
+            + scalar!(q_lc[1]) * self.witness(wires[1])?
+            + scalar!(q_lc[2]) * self.witness(wires[2])?
+            + scalar!(q_lc[3]) * self.witness(wires[3])?
+            + scalar!(q_mul[0]) * self.witness(wires[0])? * self.witness(wires[1])?
+            + scalar!(q_mul[1]) * self.witness(wires[2])? * self.witness(wires[3])?
+            + scalar!(q_c);
+        let output_var = self.create_variable(output_val)?;
+        let wires = [wires[0], wires[1], wires[2], wires[3], output_var];
+
+        self.insert_gate(
+            &wires,
+            Box::new(QuadPolyGate {
+                q_lc: *q_lc,
+                q_mul: *q_mul,
+                q_o: C::ScalarField::one(),
+                q_c,
+            }),
+        )?;
+
+        Ok(output_var)
+    }
+
+    /// Constrain a linear combination gate:
+    /// q1 * a + q2 * b + q3 * c + q4 * d  = y
+    pub fn lc_gate(
+        &mut self,
+        wires: &[Variable; GATE_WIDTH + 1],
+        coeffs: &[C::ScalarField; GATE_WIDTH],
+    ) -> Result<(), CircuitError> {
+        self.check_vars_bound(wires)?;
+
+        let wire_vars = [wires[0], wires[1], wires[2], wires[3], wires[4]];
+        self.insert_gate(&wire_vars, Box::new(LinCombGate { coeffs: *coeffs }))?;
+        Ok(())
+    }
+
+    /// Obtain a variable representing a linear combination.
+    /// Return error if variables are invalid.
+    pub fn lc(
+        &mut self,
+        wires_in: &[Variable; GATE_WIDTH],
+        coeffs: &[C::ScalarField; GATE_WIDTH],
+    ) -> Result<Variable, CircuitError> {
+        self.check_vars_bound(wires_in)?;
+
+        let vals_in: Vec<AuthenticatedScalarResult<C>> = wires_in
+            .iter()
+            .map(|&var| self.witness(var))
+            .collect::<Result<Vec<_>, CircuitError>>()?;
+
+        // calculate y as the linear combination of coeffs and vals_in
+        let y_val = vals_in
+            .iter()
+            .zip(coeffs.iter())
+            .map(|(val, coeff)| val * scalar!(*coeff))
+            .sum();
+        let y = self.create_variable(y_val)?;
+
+        let wires = [wires_in[0], wires_in[1], wires_in[2], wires_in[3], y];
+        self.lc_gate(&wires, coeffs)?;
+        Ok(y)
+    }
+
+    /// Constrain a mul-addition gate:
+    /// q_muls[0] * wires[0] *  wires[1] +  q_muls[1] * wires[2] *
+    /// wires[3] = wires[4]
+    pub fn mul_add_gate(
+        &mut self,
+        wires: &[Variable; GATE_WIDTH + 1],
+        q_muls: &[C::ScalarField; N_MUL_SELECTORS],
+    ) -> Result<(), CircuitError> {
+        self.check_vars_bound(wires)?;
+
+        let wire_vars = [wires[0], wires[1], wires[2], wires[3], wires[4]];
+        self.insert_gate(&wire_vars, Box::new(MulAddGate { coeffs: *q_muls }))?;
+        Ok(())
+    }
+
+    /// Obtain a variable representing `q12 * a * b + q34 * c * d`,
+    /// where `a, b, c, d` are input wires, and `q12`, `q34` are selectors
+    ///
+    /// Return an error if variables are invalid
+    pub fn mul_add(
+        &mut self,
+        wires_in: &[Variable; GATE_WIDTH],
+        q_muls: &[C::ScalarField; N_MUL_SELECTORS],
+    ) -> Result<Variable, CircuitError> {
+        self.check_vars_bound(wires_in)?;
+
+        let vals_in: Vec<AuthenticatedScalarResult<C>> = wires_in
+            .iter()
+            .map(|&var| self.witness(var))
+            .collect::<Result<Vec<_>, CircuitError>>()?;
+
+        // calculate y as the mul-addition of coeffs and vals_in
+        let y_val = scalar!(q_muls[0]) * &vals_in[0] * &vals_in[1]
+            + scalar!(q_muls[1]) * &vals_in[2] * &vals_in[3];
+        let y = self.create_variable(y_val)?;
+
+        let wires = [wires_in[0], wires_in[1], wires_in[2], wires_in[3], y];
+        self.mul_add_gate(&wires, q_muls)?;
+        Ok(y)
+    }
+
+    /// Create a variable representing the sum of a list of variables
+    ///
+    /// Return an error if variables are invalid
+    pub fn sum(&mut self, elems: &[Variable]) -> Result<Variable, CircuitError> {
+        if elems.is_empty() {
+            return Err(CircuitError::ParameterError(
+                "Sum over an empty slice of variables is undefined".to_string(),
+            ));
+        }
+        self.check_vars_bound(elems)?;
+
+        let mut elem_iter = elems
+            .iter()
+            .map(|elem| self.witness(*elem))
+            .collect::<Result<Vec<_>, CircuitError>>()?
+            .into_iter();
+        let sum_val = elem_iter.next().expect("cannot sum empty slice");
+        let sum_val = elem_iter.fold(sum_val, |acc, val| acc + val);
+        let sum = self.create_variable(sum_val)?;
+
+        // Pad with zeros and pack into as few gates as possibly by adding on all input
+        // wires
+        let mut padded: Vec<Variable> = elems.to_owned();
+        let gate_capacity = GATE_WIDTH - 1;
+        let padded_len = next_multiple(elems.len() - 1, gate_capacity)? + 1;
+        padded.resize(padded_len, self.zero());
+
+        // Construct a series of gates in which the output wire of the `n`th gate
+        // is the accumulation of 3 * n input wires in the sequence
+        let coeffs = [C::ScalarField::one(); GATE_WIDTH];
+        let mut accum = padded[0];
+        for i in 1..padded_len / gate_capacity {
+            accum = self.lc(
+                &[
+                    accum,
+                    padded[gate_capacity * i - 2],
+                    padded[gate_capacity * i - 1],
+                    padded[gate_capacity * i],
+                ],
+                &coeffs,
+            )?;
+        }
+
+        // Final round
+        let wires = [
+            accum,
+            padded[padded_len - 3],
+            padded[padded_len - 2],
+            padded[padded_len - 1],
+            sum,
+        ];
+        self.lc_gate(&wires, &coeffs)?;
+
+        Ok(sum)
+    }
+
     /// Constrain variable `y` to the addition of `a` and `c`, where `c` is a
-    /// constant value Return error if the input variables are invalid.
+    /// constant value
+    ///
+    /// Return an error if the input variables are invalid
     pub fn add_constant_gate(
         &mut self,
-        x: MpcVariable,
-        c: Scalar<C>,
-        y: MpcVariable,
+        x: Variable,
+        c: C::ScalarField,
+        y: Variable,
     ) -> Result<(), CircuitError> {
         self.check_var_bound(x)?;
         self.check_var_bound(y)?;
 
         let wire_vars = &[x, self.one(), 0, 0, y];
-        self.insert_gate(wire_vars, Box::new(ConstantAdditionGate(c.inner())))?;
+        self.insert_gate(wire_vars, Box::new(ConstantAdditionGate(c)))?;
         Ok(())
     }
 
-    /// Obtains a variable representing an addition with a constant value
-    /// Return error if the input variable is invalid
+    /// Create a variable representing an addition with a constant value
+    ///
+    /// Return an error if the input variable is invalid
     pub fn add_constant(
         &mut self,
-        input_var: MpcVariable,
-        elem: &Scalar<C>,
-    ) -> Result<MpcVariable, CircuitError> {
+        input_var: Variable,
+        elem: &C::ScalarField,
+    ) -> Result<Variable, CircuitError> {
         self.check_var_bound(input_var)?;
 
         let input_val = self.witness(input_var).unwrap();
-        let output_val = *elem + input_val;
+        let output_val = scalar!(*elem) + input_val;
         let output_var = self.create_variable(output_val).unwrap();
 
         self.add_constant_gate(input_var, *elem, output_var)?;
@@ -45,36 +262,76 @@ impl<C: CurveGroup> MpcPlonkCircuit<C> {
     }
 
     /// Constrain variable `y` to the product of `a` and `c`, where `c` is a
-    /// constant value Return error if the input variables are invalid.
+    /// constant value
+    ///
+    /// Return an error if the input variables are invalid.
     pub fn mul_constant_gate(
         &mut self,
-        x: MpcVariable,
-        c: Scalar<C>,
-        y: MpcVariable,
+        x: Variable,
+        c: C::ScalarField,
+        y: Variable,
     ) -> Result<(), CircuitError> {
         self.check_var_bound(x)?;
         self.check_var_bound(y)?;
 
         let wire_vars = &[x, 0, 0, 0, y];
-        self.insert_gate(wire_vars, Box::new(ConstantMultiplicationGate(c.inner())))?;
+        self.insert_gate(wire_vars, Box::new(ConstantMultiplicationGate(c)))?;
         Ok(())
     }
 
-    /// Obtains a variable representing a multiplication with a constant value
-    /// Return error if the input variable is invalid
+    /// Create a variable representing a multiplication with a constant value
+    ///
+    /// Return an error if the input variable is invalid
     pub fn mul_constant(
         &mut self,
-        input_var: MpcVariable,
-        elem: &Scalar<C>,
-    ) -> Result<MpcVariable, CircuitError> {
+        input_var: Variable,
+        elem: &C::ScalarField,
+    ) -> Result<Variable, CircuitError> {
         self.check_var_bound(input_var)?;
 
         let input_val = self.witness(input_var).unwrap();
-        let output_val = *elem * input_val;
+        let output_val = scalar!(*elem) * input_val;
         let output_var = self.create_variable(output_val).unwrap();
 
         self.mul_constant_gate(input_var, *elem, output_var)?;
 
         Ok(output_var)
+    }
+
+    /// Create a variable representing the 11th power of the input variable
+    ///
+    /// Cost: 3 constraints
+    pub fn power_11_gen(&mut self, x: Variable) -> Result<Variable, CircuitError> {
+        self.check_var_bound(x)?;
+
+        // now we prove that x^11 = x_to_11
+        let x_val = self.witness(x)?;
+        let x_to_5_val = x_val.pow(5);
+        let x_to_5 = self.create_variable(x_to_5_val)?;
+
+        let wire_vars = &[x, 0, 0, 0, x_to_5];
+        self.insert_gate(wire_vars, Box::new(FifthRootGate))?;
+
+        let x_to_10 = self.mul(x_to_5, x_to_5)?;
+        self.mul(x_to_10, x)
+    }
+
+    /// Constraint a variable to be the 11th power of another variable
+    ///
+    /// Cost: 3 constraints
+    pub fn power_11_gate(&mut self, x: Variable, x_to_11: Variable) -> Result<(), CircuitError> {
+        self.check_var_bound(x)?;
+        self.check_var_bound(x_to_11)?;
+
+        // now we prove that x^11 = x_to_11
+        let x_val = self.witness(x)?;
+        let x_to_5_val = x_val.pow(5);
+        let x_to_5 = self.create_variable(x_to_5_val)?;
+
+        let wire_vars = &[x, 0, 0, 0, x_to_5];
+        self.insert_gate(wire_vars, Box::new(FifthRootGate))?;
+
+        let x_to_10 = self.mul(x_to_5, x_to_5)?;
+        self.mul_gate(x_to_10, x, x_to_11)
     }
 }

--- a/plonk/src/multiprover/gadgets/mod.rs
+++ b/plonk/src/multiprover/gadgets/mod.rs
@@ -1,5 +1,32 @@
 //! Defines commonly used gadgets directly on the circuit type
 //!
 //! These gadgets are largely copied from the single-prover implementation
+use core::cmp::Ordering;
+
+use jf_relation::errors::CircuitError;
 
 pub mod arithmetic;
+
+// Helper function to find the next multiple of `divisor` for `current` value
+pub(crate) fn next_multiple(current: usize, divisor: usize) -> Result<usize, CircuitError> {
+    if divisor == 0 || divisor == 1 {
+        return Err(CircuitError::InternalError(
+            "can only be a multiple of divisor >= 2".to_string(),
+        ));
+    }
+
+    match current.cmp(&divisor) {
+        Ordering::Equal => Ok(current),
+        Ordering::Less => Ok(divisor),
+        Ordering::Greater => Ok((current / divisor + 1) * divisor),
+    }
+}
+
+/// A shorthand notation for wrapping a `CurveGroup`'s scalar field in
+/// an MPC fabric `Scalar`
+macro_rules! scalar {
+    ($x:expr) => {
+        Scalar::new($x)
+    };
+}
+pub(self) use scalar;

--- a/plonk/src/multiprover/proof_system/constraint_system.rs
+++ b/plonk/src/multiprover/proof_system/constraint_system.rs
@@ -28,21 +28,16 @@ use jf_relation::{
 // | Traits and Types |
 // --------------------
 
-/// The variable type in an MPC constraint system
-///
-/// This represents an index into the wire assignments as flattened out
-/// canonically
-pub type MpcVariable = usize;
 /// A variable of boolean type
-pub struct MpcBoolVar(usize);
+pub struct BoolVar(usize);
 
-impl From<MpcBoolVar> for MpcVariable {
-    fn from(value: MpcBoolVar) -> Self {
+impl From<BoolVar> for Variable {
+    fn from(value: BoolVar) -> Self {
         value.0
     }
 }
 
-impl MpcBoolVar {
+impl BoolVar {
     /// Create a new boolean variable from a variable index
     ///
     /// Do not constrain the underlying value to be boolean
@@ -86,13 +81,13 @@ pub trait MpcCircuit<C: CurveGroup> {
 
     /// Create a constant variable in the circuit, returning the index of the
     /// variable
-    fn create_constant_variable(&mut self, val: Scalar<C>) -> Result<MpcVariable, CircuitError>;
+    fn create_constant_variable(&mut self, val: Scalar<C>) -> Result<Variable, CircuitError>;
 
     /// Add a variable to the circuit; returns the index of the variable
     fn create_variable(
         &mut self,
         val: AuthenticatedScalarResult<C>,
-    ) -> Result<MpcVariable, CircuitError>;
+    ) -> Result<Variable, CircuitError>;
 
     /// Add a bool variable to the circuit; return the index of the variable.
     ///
@@ -105,100 +100,81 @@ pub trait MpcCircuit<C: CurveGroup> {
     fn create_boolean_variable(
         &mut self,
         val: AuthenticatedScalarResult<C>,
-    ) -> Result<MpcBoolVar, CircuitError> {
+    ) -> Result<BoolVar, CircuitError> {
         let var = self.create_variable(val)?;
         self.enforce_bool(var)?;
-        Ok(MpcBoolVar(var))
+        Ok(BoolVar(var))
     }
 
     /// Add a public input variable; return the index of the variable.
     fn create_public_variable(
         &mut self,
         val: AuthenticatedScalarResult<C>,
-    ) -> Result<MpcVariable, CircuitError>;
+    ) -> Result<Variable, CircuitError>;
 
     /// Set a variable to a public variable
-    fn set_variable_public(&mut self, var: MpcVariable) -> Result<(), CircuitError>;
+    fn set_variable_public(&mut self, var: Variable) -> Result<(), CircuitError>;
 
     /// Return a default variable with value zero.
-    fn zero(&self) -> MpcVariable;
+    fn zero(&self) -> Variable;
 
     /// Return a default variable with value one.
-    fn one(&self) -> MpcVariable;
+    fn one(&self) -> Variable;
 
     /// Return a default variable with value `false` (namely zero).
-    fn false_var(&self) -> MpcBoolVar {
-        MpcBoolVar::new_unchecked(self.zero())
+    fn false_var(&self) -> BoolVar {
+        BoolVar::new_unchecked(self.zero())
     }
 
     /// Return a default variable with value `true` (namely one).
-    fn true_var(&self) -> MpcBoolVar {
-        MpcBoolVar::new_unchecked(self.one())
+    fn true_var(&self) -> BoolVar {
+        BoolVar::new_unchecked(self.one())
     }
 
     /// Return the witness value of variable `idx`.
     /// Return error if the input variable is invalid.
-    fn witness(&self, idx: MpcVariable) -> Result<AuthenticatedScalarResult<C>, CircuitError>;
+    fn witness(&self, idx: Variable) -> Result<AuthenticatedScalarResult<C>, CircuitError>;
 
     /// Common gates that should be implemented in any constraint systems.
     ///
     /// Constrain a variable to a constant.
     /// Return error if `var` is an invalid variable.
-    fn enforce_constant(
-        &mut self,
-        var: MpcVariable,
-        constant: Scalar<C>,
-    ) -> Result<(), CircuitError>;
+    fn enforce_constant(&mut self, var: Variable, constant: Scalar<C>) -> Result<(), CircuitError>;
 
     /// Constrain variable `c` to the addition of `a` and `b`.
     /// Return error if the input variables are invalid.
-    fn add_gate(
-        &mut self,
-        a: MpcVariable,
-        b: MpcVariable,
-        c: MpcVariable,
-    ) -> Result<(), CircuitError>;
+    fn add_gate(&mut self, a: Variable, b: Variable, c: Variable) -> Result<(), CircuitError>;
 
     /// Obtain a variable representing an addition.
     /// Return the index of the variable.
     /// Return error if the input variables are invalid.
-    fn add(&mut self, a: MpcVariable, b: MpcVariable) -> Result<MpcVariable, CircuitError>;
+    fn add(&mut self, a: Variable, b: Variable) -> Result<Variable, CircuitError>;
 
     /// Constrain variable `c` to the subtraction of `a` and `b`.
     /// Return error if the input variables are invalid.
-    fn sub_gate(
-        &mut self,
-        a: MpcVariable,
-        b: MpcVariable,
-        c: MpcVariable,
-    ) -> Result<(), CircuitError>;
+    fn sub_gate(&mut self, a: Variable, b: Variable, c: Variable) -> Result<(), CircuitError>;
 
     /// Obtain a variable representing a subtraction.
     /// Return the index of the variable.
     /// Return error if the input variables are invalid.
-    fn sub(&mut self, a: MpcVariable, b: MpcVariable) -> Result<MpcVariable, CircuitError>;
+    fn sub(&mut self, a: Variable, b: Variable) -> Result<Variable, CircuitError>;
 
     /// Constrain variable `c` to the multiplication of `a` and `b`.
     /// Return error if the input variables are invalid.
-    fn mul_gate(
-        &mut self,
-        a: MpcVariable,
-        b: MpcVariable,
-        c: MpcVariable,
-    ) -> Result<(), CircuitError>;
+    fn mul_gate(&mut self, a: Variable, b: Variable, c: Variable) -> Result<(), CircuitError>;
 
     /// Obtain a variable representing a multiplication.
     /// Return the index of the variable.
     /// Return error if the input variables are invalid.
-    fn mul(&mut self, a: MpcVariable, b: MpcVariable) -> Result<MpcVariable, CircuitError>;
+    fn mul(&mut self, a: Variable, b: Variable) -> Result<Variable, CircuitError>;
 
     /// Constrain a variable to a bool.
     /// Return error if the input is invalid.
-    fn enforce_bool(&mut self, a: MpcVariable) -> Result<(), CircuitError>;
+    fn enforce_bool(&mut self, a: Variable) -> Result<(), CircuitError>;
 
     /// Constrain two variables to have the same value.
     /// Return error if the input variables are invalid.
-    fn enforce_equal(&mut self, a: MpcVariable, b: MpcVariable) -> Result<(), CircuitError>;
+    fn enforce_equal(&mut self, a: Variable, b: Variable) -> Result<(), CircuitError>;
 
     /// Pad the circuit with n dummy gates
     fn pad_gates(&mut self, n: usize);
@@ -269,7 +245,7 @@ where
     /// The gate of each constraint
     gates: Vec<Box<dyn Gate<C::ScalarField>>>,
     /// The map from arithmetic gate wires to variables
-    wire_variables: [Vec<MpcVariable>; GATE_WIDTH + 2],
+    wire_variables: [Vec<Variable>; GATE_WIDTH + 2],
     /// The IO gates for the list of public input variables
     pub_input_gate_ids: Vec<GateId>,
     /// The assignment of the witness variables
@@ -338,7 +314,7 @@ where
     /// Insert an algebraic gate
     pub fn insert_gate(
         &mut self,
-        wire_vars: &[MpcVariable; GATE_WIDTH + 1],
+        wire_vars: &[Variable; GATE_WIDTH + 1],
         gate: Box<dyn Gate<C::ScalarField>>,
     ) -> Result<(), CircuitError> {
         self.check_finalize_flag(false)?;
@@ -389,9 +365,9 @@ where
     pub(crate) fn create_boolean_variable_unchecked(
         &mut self,
         a: AuthenticatedScalarResult<C>,
-    ) -> Result<MpcBoolVar, CircuitError> {
+    ) -> Result<BoolVar, CircuitError> {
         let var = self.create_variable(a)?;
-        Ok(MpcBoolVar::new_unchecked(var))
+        Ok(BoolVar::new_unchecked(var))
     }
 }
 
@@ -763,7 +739,7 @@ impl<C: CurveGroup> MpcCircuit<C> for MpcPlonkCircuit<C> {
         panic("`check_circuit_satisfiability` should not be called outside of tests, this method leaks privacy")
     }
 
-    fn create_constant_variable(&mut self, val: Scalar<C>) -> Result<MpcVariable, CircuitError> {
+    fn create_constant_variable(&mut self, val: Scalar<C>) -> Result<Variable, CircuitError> {
         let authenticated_val = self.fabric.one_authenticated() * val;
         let var = self.create_variable(authenticated_val)?;
         self.enforce_constant(var, val)?;
@@ -774,7 +750,7 @@ impl<C: CurveGroup> MpcCircuit<C> for MpcPlonkCircuit<C> {
     fn create_variable(
         &mut self,
         val: AuthenticatedScalarResult<C>,
-    ) -> Result<MpcVariable, CircuitError> {
+    ) -> Result<Variable, CircuitError> {
         self.check_finalize_flag(false)?;
         self.witness.push(val);
         self.num_vars += 1;
@@ -785,14 +761,14 @@ impl<C: CurveGroup> MpcCircuit<C> for MpcPlonkCircuit<C> {
     fn create_public_variable(
         &mut self,
         val: AuthenticatedScalarResult<C>,
-    ) -> Result<MpcVariable, CircuitError> {
+    ) -> Result<Variable, CircuitError> {
         let var = self.create_variable(val)?;
         self.set_variable_public(var)?;
 
         Ok(var)
     }
 
-    fn set_variable_public(&mut self, var: MpcVariable) -> Result<(), CircuitError> {
+    fn set_variable_public(&mut self, var: Variable) -> Result<(), CircuitError> {
         self.check_finalize_flag(false)?;
         self.pub_input_gate_ids.push(self.num_gates());
 
@@ -802,25 +778,21 @@ impl<C: CurveGroup> MpcCircuit<C> for MpcPlonkCircuit<C> {
         Ok(())
     }
 
-    fn zero(&self) -> MpcVariable {
+    fn zero(&self) -> Variable {
         0
     }
 
-    fn one(&self) -> MpcVariable {
+    fn one(&self) -> Variable {
         1
     }
 
-    fn witness(&self, idx: MpcVariable) -> Result<AuthenticatedScalarResult<C>, CircuitError> {
+    fn witness(&self, idx: Variable) -> Result<AuthenticatedScalarResult<C>, CircuitError> {
         self.check_var_bound(idx)?;
 
         Ok(self.witness[idx].clone())
     }
 
-    fn enforce_constant(
-        &mut self,
-        var: MpcVariable,
-        constant: Scalar<C>,
-    ) -> Result<(), CircuitError> {
+    fn enforce_constant(&mut self, var: Variable, constant: Scalar<C>) -> Result<(), CircuitError> {
         self.check_var_bound(var)?;
 
         let wire_vars = &[0, 0, 0, 0, var];
@@ -828,12 +800,7 @@ impl<C: CurveGroup> MpcCircuit<C> for MpcPlonkCircuit<C> {
         Ok(())
     }
 
-    fn add_gate(
-        &mut self,
-        a: MpcVariable,
-        b: MpcVariable,
-        c: MpcVariable,
-    ) -> Result<(), CircuitError> {
+    fn add_gate(&mut self, a: Variable, b: Variable, c: Variable) -> Result<(), CircuitError> {
         self.check_var_bound(a)?;
         self.check_var_bound(b)?;
         self.check_var_bound(c)?;
@@ -843,7 +810,7 @@ impl<C: CurveGroup> MpcCircuit<C> for MpcPlonkCircuit<C> {
         Ok(())
     }
 
-    fn add(&mut self, a: MpcVariable, b: MpcVariable) -> Result<MpcVariable, CircuitError> {
+    fn add(&mut self, a: Variable, b: Variable) -> Result<Variable, CircuitError> {
         self.check_var_bound(a)?;
         self.check_var_bound(b)?;
 
@@ -854,12 +821,7 @@ impl<C: CurveGroup> MpcCircuit<C> for MpcPlonkCircuit<C> {
         Ok(c)
     }
 
-    fn sub_gate(
-        &mut self,
-        a: MpcVariable,
-        b: MpcVariable,
-        c: MpcVariable,
-    ) -> Result<(), CircuitError> {
+    fn sub_gate(&mut self, a: Variable, b: Variable, c: Variable) -> Result<(), CircuitError> {
         self.check_var_bound(a)?;
         self.check_var_bound(b)?;
         self.check_var_bound(c)?;
@@ -869,7 +831,7 @@ impl<C: CurveGroup> MpcCircuit<C> for MpcPlonkCircuit<C> {
         Ok(())
     }
 
-    fn sub(&mut self, a: MpcVariable, b: MpcVariable) -> Result<MpcVariable, CircuitError> {
+    fn sub(&mut self, a: Variable, b: Variable) -> Result<Variable, CircuitError> {
         self.check_var_bound(a)?;
         self.check_var_bound(b)?;
 
@@ -880,12 +842,7 @@ impl<C: CurveGroup> MpcCircuit<C> for MpcPlonkCircuit<C> {
         Ok(c)
     }
 
-    fn mul_gate(
-        &mut self,
-        a: MpcVariable,
-        b: MpcVariable,
-        c: MpcVariable,
-    ) -> Result<(), CircuitError> {
+    fn mul_gate(&mut self, a: Variable, b: Variable, c: Variable) -> Result<(), CircuitError> {
         self.check_var_bound(a)?;
         self.check_var_bound(b)?;
         self.check_var_bound(c)?;
@@ -895,7 +852,7 @@ impl<C: CurveGroup> MpcCircuit<C> for MpcPlonkCircuit<C> {
         Ok(())
     }
 
-    fn mul(&mut self, a: MpcVariable, b: MpcVariable) -> Result<MpcVariable, CircuitError> {
+    fn mul(&mut self, a: Variable, b: Variable) -> Result<Variable, CircuitError> {
         self.check_var_bound(a)?;
         self.check_var_bound(b)?;
 
@@ -906,7 +863,7 @@ impl<C: CurveGroup> MpcCircuit<C> for MpcPlonkCircuit<C> {
         Ok(c)
     }
 
-    fn enforce_bool(&mut self, a: MpcVariable) -> Result<(), CircuitError> {
+    fn enforce_bool(&mut self, a: Variable) -> Result<(), CircuitError> {
         self.check_var_bound(a)?;
 
         let wire_vars = &[a, a, 0, 0, a];
@@ -914,7 +871,7 @@ impl<C: CurveGroup> MpcCircuit<C> for MpcPlonkCircuit<C> {
         Ok(())
     }
 
-    fn enforce_equal(&mut self, a: MpcVariable, b: MpcVariable) -> Result<(), CircuitError> {
+    fn enforce_equal(&mut self, a: Variable, b: Variable) -> Result<(), CircuitError> {
         self.check_var_bound(a)?;
         self.check_var_bound(b)?;
 

--- a/plonk/src/multiprover/proof_system/prover.rs
+++ b/plonk/src/multiprover/proof_system/prover.rs
@@ -953,12 +953,12 @@ pub(crate) mod test {
 
         // Each loop is (res + 1) * (res + 1)
         for _ in 0..10 {
-            res = circuit.add_constant(res, &Scalar::one()).unwrap();
+            res = circuit.add_constant(res, &TestScalar::one()).unwrap();
             res = circuit.mul(res, res).unwrap();
         }
 
         // Multiply by zero
-        let zero = circuit.mul_constant(res, &Scalar::zero()).unwrap();
+        let zero = circuit.mul_constant(res, &TestScalar::zero()).unwrap();
         circuit.enforce_equal(zero, circuit.zero()).unwrap();
 
         circuit.finalize_for_arithmetization().unwrap();

--- a/relation/src/gates/arithmetic.rs
+++ b/relation/src/gates/arithmetic.rs
@@ -6,6 +6,8 @@
 
 //! Implementation of arithmetic gates
 
+#![allow(missing_docs)]
+
 use super::Gate;
 use crate::constants::{GATE_WIDTH, N_MUL_SELECTORS};
 use ark_ff::Field;
@@ -205,10 +207,10 @@ impl<F: Field> Gate<F> for FifthRootGate {
 /// A deg-2 polynomial gate
 #[derive(Clone)]
 pub struct QuadPolyGate<F: Field> {
-    pub(crate) q_lc: [F; GATE_WIDTH],
-    pub(crate) q_mul: [F; N_MUL_SELECTORS],
-    pub(crate) q_o: F,
-    pub(crate) q_c: F,
+    pub q_lc: [F; GATE_WIDTH],
+    pub q_mul: [F; N_MUL_SELECTORS],
+    pub q_o: F,
+    pub q_c: F,
 }
 impl<F> Gate<F> for QuadPolyGate<F>
 where
@@ -234,7 +236,7 @@ where
 /// A linear combination gate
 #[derive(Clone)]
 pub struct LinCombGate<F: Field> {
-    pub(crate) coeffs: [F; GATE_WIDTH],
+    pub coeffs: [F; GATE_WIDTH],
 }
 impl<F> Gate<F> for LinCombGate<F>
 where
@@ -254,7 +256,7 @@ where
 /// A multiplication-then-addition gate
 #[derive(Clone)]
 pub struct MulAddGate<F: Field> {
-    pub(crate) coeffs: [F; N_MUL_SELECTORS],
+    pub coeffs: [F; N_MUL_SELECTORS],
 }
 impl<F> Gate<F> for MulAddGate<F>
 where


### PR DESCRIPTION
### Purpose
This PR adds the arithmetic gadgets from the single-prover implementation to the multi-prover Plonk implementation. Only the arithmetic gadgets are added here as the logical, comparison, etc gates all require more complicated MPC circuitry (already implemented in `renegade/circuits`) to be realized efficiently.

See the single-prover implementation [here](https://github.com/renegade-fi/mpc-jellyfish/blob/main/relation/src/gadgets/arithmetic.rs) for further reference

### Testing
- Unit tests pass