### PR TITLE
multiprover: structs: Export `CollaborativeProof` and related structs

### DIFF
--- a/plonk/src/multiprover/proof_system/mod.rs
+++ b/plonk/src/multiprover/proof_system/mod.rs
@@ -10,4 +10,4 @@ mod structs;
 pub use constraint_system::*;
 pub(crate) use prover::*;
 pub use snark::*;
-pub(crate) use structs::*;
+pub use structs::*;

--- a/plonk/src/multiprover/proof_system/structs.rs
+++ b/plonk/src/multiprover/proof_system/structs.rs
@@ -31,7 +31,7 @@ pub(crate) struct MpcOracles<C: CurveGroup> {
 /// We hold handles to incomplete computations (transcript evaluations) instead
 /// of the underlying values, as per the MPC framework's standard
 #[derive(Debug)]
-pub struct MpcChallenges<C: CurveGroup> {
+pub(crate) struct MpcChallenges<C: CurveGroup> {
     /// The parameterization of the random linear combination of gate, copy, and
     /// grand product polynomials
     pub alpha: ScalarResult<C>,


### PR DESCRIPTION
### Purpose
This PR adjusts the visibility of the `structs` module to public and hides internal structs behind `pub(crate)`. In particular this exports `CollaborativeProof` and `CollaborativeProofOpening`