### PR TITLE
relation: constriant-system: Add `pow5` method to `ConstraintSystem`

### DIFF
--- a/plonk/src/multiprover/proof_system/constraint_system.rs
+++ b/plonk/src/multiprover/proof_system/constraint_system.rs
@@ -19,8 +19,8 @@ use mpc_relation::{
     errors::CircuitError,
     gates::{
         AdditionGate, BoolGate, ConstantAdditionGate, ConstantGate, ConstantMultiplicationGate,
-        EqualityGate, Gate, IoGate, LinCombGate, MulAddGate, MultiplicationGate, PaddingGate,
-        SubtractionGate,
+        EqualityGate, FifthRootGate, Gate, IoGate, LinCombGate, MulAddGate, MultiplicationGate,
+        PaddingGate, SubtractionGate,
     },
     ConstraintSystem, GateId, Variable, WireId,
 };
@@ -1039,6 +1039,17 @@ impl<C: CurveGroup> ConstraintSystem<C::ScalarField> for MpcPlonkCircuit<C> {
         self.mul_constant_gate(input_var, *elem, output_var)?;
 
         Ok(output_var)
+    }
+
+    /// Creates a variable that is the fifth power of the input
+    fn pow5(&mut self, x: Variable) -> Result<Variable, CircuitError> {
+        let val = self.witness(x)?;
+        let res = val.pow(5);
+        let res_var = self.create_variable(res)?;
+
+        let wire_vars = &[x, 0, 0, 0, res_var];
+        self.insert_gate(wire_vars, Box::new(FifthRootGate))?;
+        Ok(res_var)
     }
 }
 

--- a/relation/src/constraint_system.rs
+++ b/relation/src/constraint_system.rs
@@ -261,6 +261,9 @@ pub trait ConstraintSystem<F: Field> {
     /// Return error if the input variable is invalid
     fn mul_constant(&mut self, input_var: Variable, elem: &F) -> Result<Variable, CircuitError>;
 
+    /// Takes the input to the fifth power
+    fn pow5(&mut self, x: Variable) -> Result<Variable, CircuitError>;
+
     // ---------------
     // | Constraints |
     // ---------------
@@ -1056,6 +1059,16 @@ impl<F: FftField> ConstraintSystem<F> for PlonkCircuit<F> {
         self.mul_constant_gate(input_var, *elem, output_var)?;
 
         Ok(output_var)
+    }
+
+    fn pow5(&mut self, x: Variable) -> Result<Variable, CircuitError> {
+        let val = self.witness(x)?;
+        let res = val.pow([5]);
+        let res_var = self.create_variable(res)?;
+
+        let wire_vars = &[x, 0, 0, 0, res_var];
+        self.insert_gate(wire_vars, Box::new(FifthRootGate))?;
+        Ok(res_var)
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR adds a `pow5` method to the `ConstraintSystem` trait that computes the fifth power of its input. This gadget is used downstream in Poseidon permutation implementations.

### Testing
- Unit tests pass