### PR TITLE
relation: gates: logic: Add `MuxGate` and implementation in `ConstraintSystem`

### DIFF
--- a/relation/src/gates/logic.rs
+++ b/relation/src/gates/logic.rs
@@ -53,3 +53,36 @@ where
         F::one()
     }
 }
+
+/// A gate for selecting one of two inputs based on a selector
+///
+/// I.e. implements if self { a } else { b }
+///
+/// Assuming that the selector is either 0 or 1 (this should be constrained
+/// elsewhere) we can do this via the following:
+///     sel * a + (1 - sel) * b
+///     = sel * a + b - sel * b
+/// We can achieve this by setting q_lc = [0, 0, 0, 1]
+/// and q_mul to [1, -1]
+///
+/// Then the input wires are [sel, a, sel, b] we end up with
+///    q_mul[0] * sel * a + q_lc[3] * b + q_mul[1] * sel * b
+#[derive(Clone)]
+pub struct MuxGate;
+impl<F: Field> Gate<F> for MuxGate {
+    fn name(&self) -> &'static str {
+        "Mux Gate"
+    }
+
+    fn q_lc(&self) -> [F; GATE_WIDTH] {
+        [F::zero(), F::zero(), F::zero(), F::one()]
+    }
+
+    fn q_mul(&self) -> [F; N_MUL_SELECTORS] {
+        [F::one(), -F::one()]
+    }
+
+    fn q_o(&self) -> F {
+        F::one()
+    }
+}


### PR DESCRIPTION
### Purpose
This PR introduces the `MuxGate` and its integration into the `ConstraintSystem` trait. This gate implements:
```rust
if selector { a } else { b }
```
and is used to multiplex between two inputs based on a boolean selector. The use of `BoolVar` in the interface implicitly guarantees that the variable _is_ actually boolean (i.e. zero or one). 

This gate is used in conditional select logic downstream.

### Testing
- Unit tests pass