### PR TITLE
relation: traits: Refactor traits into separate module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,10 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ github.token }}
+          args: >
+            --tests
+            --benches
+            --all-features
 
       - name: Audit
         uses: actions-rs/audit-check@v1
@@ -59,19 +63,12 @@ jobs:
           token: ${{ github.token }}
 
       - name: Check Bench
-        run: cargo bench --features test-srs --no-run
+        run: cargo bench --all-features --no-run
 
       - name: Check all tests and binaries compilation
         run: |
-          cargo check --workspace --tests --lib --bins
+          cargo check --workspace --all-features --tests --lib --bins
           cargo check --workspace --all-features
-
-      - name: Check no_std support and WASM compilation
-        env:
-          RUSTFLAGS: '-C target-cpu=generic --cfg curve25519_dalek_backend="u32"'
-        run: |
-          cargo check --no-default-features
-          cargo build --target wasm32-unknown-unknown --no-default-features
 
       - name: Test
         run: bash ./scripts/run_tests.sh

--- a/plonk/benches/bench.rs
+++ b/plonk/benches/bench.rs
@@ -19,7 +19,7 @@ use mpc_plonk::{
     transcript::StandardTranscript,
     PlonkType,
 };
-use mpc_relation::{ConstraintSystem, PlonkCircuit};
+use mpc_relation::{traits::*, PlonkCircuit};
 use std::time::Instant;
 
 const NUM_REPETITIONS: usize = 10;

--- a/plonk/examples/proof_of_exp.rs
+++ b/plonk/examples/proof_of_exp.rs
@@ -25,7 +25,7 @@ use mpc_plonk::{
     proof_system::{PlonkKzgSnark, UniversalSNARK},
     transcript::StandardTranscript,
 };
-use mpc_relation::{gadgets::ecc::TEPoint, Arithmetization, Circuit, PlonkCircuit};
+use mpc_relation::{gadgets::ecc::TEPoint, traits::*, PlonkCircuit};
 use rand_chacha::ChaCha20Rng;
 
 // The following example proves knowledge of exponent.

--- a/plonk/src/circuit/plonk_verifier/gadgets.rs
+++ b/plonk/src/circuit/plonk_verifier/gadgets.rs
@@ -25,7 +25,7 @@ use mpc_relation::{
         ecc::{PointVariable, SWToTEConParam},
         ultraplonk::mod_arith::{FpElem, FpElemVar},
     },
-    Circuit, PlonkCircuit,
+    PlonkCircuit,
 };
 
 /// Aggregate polynomial commitments into a single commitment (in the
@@ -464,7 +464,7 @@ mod test {
     use ark_std::{vec, UniformRand};
     use jf_primitives::rescue::RescueParameter;
     use jf_utils::{field_switching, test_rng};
-    use mpc_relation::{Circuit, MergeableCircuitType};
+    use mpc_relation::MergeableCircuitType;
 
     const RANGE_BIT_LEN_FOR_TEST: usize = 16;
     #[test]

--- a/plonk/src/circuit/plonk_verifier/mod.rs
+++ b/plonk/src/circuit/plonk_verifier/mod.rs
@@ -20,7 +20,8 @@ use mpc_relation::{
         ecc::{MultiScalarMultiplicationCircuit, PointVariable, SWToTEConParam, TEPoint},
         ultraplonk::mod_arith::{FpElem, FpElemVar},
     },
-    ConstraintSystem, PlonkCircuit, Variable,
+    traits::*,
+    PlonkCircuit, Variable,
 };
 
 mod gadgets;
@@ -336,7 +337,7 @@ mod test {
     use jf_utils::{field_switching, test_rng};
     use mpc_relation::{
         gadgets::{ecc::TEPoint, test_utils::test_variable_independence_for_circuit},
-        Circuit, MergeableCircuitType,
+        MergeableCircuitType,
     };
 
     const RANGE_BIT_LEN_FOR_TEST: usize = 16;

--- a/plonk/src/circuit/plonk_verifier/poly.rs
+++ b/plonk/src/circuit/plonk_verifier/poly.rs
@@ -738,7 +738,6 @@ mod test {
     use ark_poly::Radix2EvaluationDomain;
     use ark_std::{One, UniformRand};
     use jf_utils::{field_switching, test_rng};
-    use mpc_relation::Circuit;
 
     const RANGE_BIT_LEN_FOR_TEST: usize = 16;
 

--- a/plonk/src/circuit/transcript.rs
+++ b/plonk/src/circuit/transcript.rs
@@ -21,7 +21,8 @@ use mpc_relation::{
         ecc::{PointVariable, SWToTEConParam},
         ultraplonk::mod_arith::FpElemVar,
     },
-    ConstraintSystem, PlonkCircuit, Variable,
+    traits::*,
+    PlonkCircuit, Variable,
 };
 
 /// Struct of variables representing a Rescue transcript type, including
@@ -233,7 +234,7 @@ mod tests {
     use ark_std::{format, UniformRand};
     use jf_primitives::pcs::prelude::{Commitment, UnivariateVerifierParam};
     use jf_utils::{bytes_to_field_elements, field_switching, test_rng};
-    use mpc_relation::{gadgets::ecc::TEPoint, Circuit};
+    use mpc_relation::gadgets::ecc::TEPoint;
 
     const RANGE_BIT_LEN_FOR_TEST: usize = 16;
     #[test]

--- a/plonk/src/multiprover/gadgets/arithmetic.rs
+++ b/plonk/src/multiprover/gadgets/arithmetic.rs
@@ -7,7 +7,8 @@ use mpc_relation::{
     constants::{GATE_WIDTH, N_MUL_SELECTORS},
     errors::CircuitError,
     gates::{FifthRootGate, QuadPolyGate},
-    ConstraintSystem, Variable,
+    traits::*,
+    Variable,
 };
 
 use crate::multiprover::proof_system::{MpcCircuit, MpcPlonkCircuit};

--- a/plonk/src/multiprover/proof_system/constraint_system.rs
+++ b/plonk/src/multiprover/proof_system/constraint_system.rs
@@ -22,7 +22,8 @@ use mpc_relation::{
         EqualityGate, FifthRootGate, Gate, IoGate, LinCombGate, MulAddGate, MultiplicationGate,
         MuxGate, PaddingGate, SubtractionGate,
     },
-    BoolVar, ConstraintSystem, GateId, Variable, WireId,
+    traits::*,
+    BoolVar, GateId, Variable, WireId,
 };
 
 use crate::multiprover::gadgets::{next_multiple, scalar};
@@ -234,25 +235,6 @@ where
         circuit.enforce_constant(1, C::ScalarField::one()).unwrap();
 
         circuit
-    }
-
-    /// Insert an algebraic gate
-    pub fn insert_gate(
-        &mut self,
-        wire_vars: &[Variable; GATE_WIDTH + 1],
-        gate: Box<dyn Gate<C::ScalarField>>,
-    ) -> Result<(), CircuitError> {
-        self.check_finalize_flag(false)?;
-
-        for (wire_var, wire_variable) in wire_vars
-            .iter()
-            .zip(self.wire_variables.iter_mut().take(GATE_WIDTH + 1))
-        {
-            wire_variable.push(*wire_var)
-        }
-
-        self.gates.push(gate);
-        Ok(())
     }
 
     /// Checks if a variable is strictly less than the number of variables.
@@ -728,6 +710,25 @@ impl<C: CurveGroup> ConstraintSystem<C::ScalarField> for MpcPlonkCircuit<C> {
         for _ in 0..n {
             self.insert_gate(wire_vars, Box::new(EqualityGate)).unwrap();
         }
+    }
+
+    /// Insert an algebraic gate
+    fn insert_gate(
+        &mut self,
+        wire_vars: &[Variable; GATE_WIDTH + 1],
+        gate: Box<dyn Gate<C::ScalarField>>,
+    ) -> Result<(), CircuitError> {
+        self.check_finalize_flag(false)?;
+
+        for (wire_var, wire_variable) in wire_vars
+            .iter()
+            .zip(self.wire_variables.iter_mut().take(GATE_WIDTH + 1))
+        {
+            wire_variable.push(*wire_var)
+        }
+
+        self.gates.push(gate);
+        Ok(())
     }
 
     fn enforce_constant(

--- a/plonk/src/multiprover/proof_system/prover.rs
+++ b/plonk/src/multiprover/proof_system/prover.rs
@@ -821,7 +821,7 @@ pub(crate) mod test {
     use futures::{future::join_all, prelude::*};
     use itertools::Itertools;
     use jf_primitives::pcs::prelude::Commitment;
-    use mpc_relation::{Arithmetization, Circuit, ConstraintSystem, PlonkCircuit};
+    use mpc_relation::{traits::*, PlonkCircuit};
     use rand::thread_rng;
 
     use crate::{

--- a/plonk/src/multiprover/proof_system/snark.rs
+++ b/plonk/src/multiprover/proof_system/snark.rs
@@ -192,7 +192,7 @@ mod tests {
     };
     use futures::future::join_all;
     use itertools::Itertools;
-    use mpc_relation::{ConstraintSystem, PlonkType};
+    use mpc_relation::{traits::*, PlonkType};
     use rand::{thread_rng, Rng};
 
     use crate::{

--- a/plonk/src/proof_system/batch_arg.rs
+++ b/plonk/src/proof_system/batch_arg.rs
@@ -29,9 +29,7 @@ use ark_std::{
 };
 use jf_primitives::rescue::RescueParameter;
 use jf_utils::multi_pairing;
-use mpc_relation::{
-    gadgets::ecc::SWToTEConParam, Circuit, ConstraintSystem, MergeableCircuitType, PlonkCircuit,
-};
+use mpc_relation::{gadgets::ecc::SWToTEConParam, traits::*, MergeableCircuitType, PlonkCircuit};
 
 /// A batching argument.
 pub struct BatchArgument<E: Pairing>(PhantomData<E>);

--- a/plonk/src/proof_system/mod.rs
+++ b/plonk/src/proof_system/mod.rs
@@ -12,7 +12,7 @@ use ark_std::{
     rand::{CryptoRng, RngCore},
     vec::Vec,
 };
-use mpc_relation::Arithmetization;
+use mpc_relation::traits::*;
 pub mod batch_arg;
 pub(crate) mod prover;
 pub(crate) mod snark;

--- a/plonk/src/proof_system/prover.rs
+++ b/plonk/src/proof_system/prover.rs
@@ -32,7 +32,7 @@ use jf_primitives::pcs::{
     PolynomialCommitmentScheme,
 };
 use jf_utils::par_utils::parallelizable_slice_iter;
-use mpc_relation::{constants::GATE_WIDTH, Arithmetization};
+use mpc_relation::{constants::GATE_WIDTH, traits::*};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 

--- a/plonk/src/proof_system/snark.rs
+++ b/plonk/src/proof_system/snark.rs
@@ -39,7 +39,7 @@ use jf_primitives::{
 };
 use jf_utils::par_utils::parallelizable_slice_iter;
 use mpc_relation::{
-    constants::compute_coset_representatives, gadgets::ecc::SWToTEConParam, Arithmetization,
+    constants::compute_coset_representatives, gadgets::ecc::SWToTEConParam, traits::*,
 };
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -690,8 +690,8 @@ pub mod test {
     };
     use jf_utils::test_rng;
     use mpc_relation::{
-        constants::GATE_WIDTH, gadgets::ecc::SWToTEConParam, Arithmetization, Circuit,
-        ConstraintSystem, MergeableCircuitType, PlonkCircuit,
+        constants::GATE_WIDTH, gadgets::ecc::SWToTEConParam, traits::*, MergeableCircuitType,
+        PlonkCircuit,
     };
 
     // Different `m`s lead to different circuits.

--- a/primitives/src/circuit/commitment.rs
+++ b/primitives/src/circuit/commitment.rs
@@ -11,7 +11,7 @@ use crate::{
     utils::pad_with,
 };
 use ark_std::vec;
-use mpc_relation::{errors::CircuitError, ConstraintSystem, PlonkCircuit, Variable};
+use mpc_relation::{errors::CircuitError, traits::*, PlonkCircuit, Variable};
 
 use super::rescue::RescueNativeGadget;
 
@@ -53,7 +53,7 @@ mod tests {
     use ark_ff::UniformRand;
     use ark_std::vec::Vec;
     use itertools::Itertools;
-    use mpc_relation::{Circuit, PlonkCircuit, Variable};
+    use mpc_relation::{traits::*, PlonkCircuit, Variable};
 
     const TEST_INPUT_LEN: usize = 10;
     const TEST_INPUT_LEN_PLUS_ONE: usize = 10 + 1;

--- a/primitives/src/circuit/elgamal.rs
+++ b/primitives/src/circuit/elgamal.rs
@@ -21,7 +21,8 @@ use jf_utils::compute_len_to_next_multiple;
 use mpc_relation::{
     errors::CircuitError,
     gadgets::ecc::{PointVariable, TEPoint},
-    Circuit, ConstraintSystem, PlonkCircuit, Variable,
+    traits::*,
+    PlonkCircuit, Variable,
 };
 
 /// Variables holding an encryption key.
@@ -265,7 +266,7 @@ mod tests {
     use ark_ff::UniformRand;
     use ark_std::{vec, vec::Vec};
     use jf_utils::fr_to_fq;
-    use mpc_relation::{gadgets::ecc::TEPoint, Circuit, PlonkCircuit, Variable};
+    use mpc_relation::{gadgets::ecc::TEPoint, traits::*, PlonkCircuit, Variable};
 
     #[test]
     fn apply_counter_mode_stream_no_padding() {

--- a/primitives/src/circuit/merkle_tree/mod.rs
+++ b/primitives/src/circuit/merkle_tree/mod.rs
@@ -8,9 +8,7 @@
 //! RescueMerkleTree and RescueSparseMerkleTree.
 
 use ark_ff::PrimeField;
-use mpc_relation::{
-    errors::CircuitError, BoolVar, Circuit, ConstraintSystem, PlonkCircuit, Variable,
-};
+use mpc_relation::{errors::CircuitError, traits::*, BoolVar, PlonkCircuit, Variable};
 
 mod universal_merkle_tree;
 use ark_std::{string::ToString, vec::Vec};
@@ -34,7 +32,7 @@ use super::rescue::RescueNativeGadget;
 /// ```
 /// use ark_bls12_377::Fq;
 /// use jf_primitives::circuit::merkle_tree::MerkleTreeGadget;
-/// use mpc_relation::{Circuit, PlonkCircuit};
+/// use mpc_relation::{traits::*, PlonkCircuit};
 /// use jf_primitives::merkle_tree::{prelude::RescueMerkleTree, MerkleTreeScheme, MerkleCommitment};
 ///
 /// let mut circuit = PlonkCircuit::<Fq>::new_turbo_plonk();
@@ -119,7 +117,7 @@ where
 /// ```
 /// use ark_bls12_377::Fq;
 /// use jf_primitives::circuit::merkle_tree::{MerkleTreeGadget, UniversalMerkleTreeGadget};
-/// use mpc_relation::{Circuit, PlonkCircuit};
+/// use mpc_relation::{traits::*, PlonkCircuit};
 /// use jf_primitives::merkle_tree::{MerkleTreeScheme, MerkleCommitment, UniversalMerkleTreeScheme,
 ///     prelude::RescueSparseMerkleTree};
 /// use hashbrown::HashMap;
@@ -459,7 +457,7 @@ mod test {
     use ark_ed_on_bls12_381_bandersnatch::Fq as FqEd381b;
     use ark_ed_on_bn254::Fq as FqEd254;
     use ark_std::{boxed::Box, vec::Vec};
-    use mpc_relation::{Circuit, PlonkCircuit, Variable};
+    use mpc_relation::{traits::*, PlonkCircuit, Variable};
 
     #[test]
     fn test_permute() {

--- a/primitives/src/circuit/merkle_tree/universal_merkle_tree.rs
+++ b/primitives/src/circuit/merkle_tree/universal_merkle_tree.rs
@@ -15,9 +15,7 @@ use crate::{
     rescue::RescueParameter,
 };
 use ark_std::vec::Vec;
-use mpc_relation::{
-    errors::CircuitError, BoolVar, Circuit, ConstraintSystem, PlonkCircuit, Variable,
-};
+use mpc_relation::{errors::CircuitError, traits::*, BoolVar, PlonkCircuit, Variable};
 
 type SparseMerkleTree<F> = RescueSparseMerkleTree<BigUint, F>;
 use num_bigint::BigUint;
@@ -134,7 +132,7 @@ mod test {
     use ark_ed_on_bls12_381_bandersnatch::Fq as FqEd381b;
     use ark_ed_on_bn254::Fq as FqEd254;
     use hashbrown::HashMap;
-    use mpc_relation::{Circuit, PlonkCircuit};
+    use mpc_relation::{traits::*, PlonkCircuit};
     use num_bigint::BigUint;
 
     type SparseMerkleTree<F> = RescueSparseMerkleTree<BigUint, F>;

--- a/primitives/src/circuit/prf.rs
+++ b/primitives/src/circuit/prf.rs
@@ -40,7 +40,7 @@ mod tests {
     use ark_ed_on_bn254::Fq as FqEd254;
     use ark_ff::UniformRand;
     use ark_std::vec::Vec;
-    use mpc_relation::{Circuit, PlonkCircuit, Variable};
+    use mpc_relation::{traits::*, PlonkCircuit, Variable};
 
     macro_rules! test_prf_circuit {
         ($base_field:tt) => {

--- a/primitives/src/circuit/rescue/mod.rs
+++ b/primitives/src/circuit/rescue/mod.rs
@@ -12,7 +12,7 @@ mod non_native;
 
 use ark_ff::PrimeField;
 use ark_std::vec::Vec;
-use mpc_relation::{errors::CircuitError, Circuit};
+use mpc_relation::{errors::CircuitError, traits::*};
 pub use native::{RescueNativeGadget, RescueStateVar};
 pub use non_native::{RescueNonNativeGadget, RescueNonNativeStateVar};
 

--- a/primitives/src/circuit/rescue/native.rs
+++ b/primitives/src/circuit/rescue/native.rs
@@ -15,7 +15,8 @@ use mpc_relation::{
     constants::GATE_WIDTH,
     errors::{CircuitError, CircuitError::ParameterError},
     gates::{FifthRootGate, Gate},
-    Circuit, ConstraintSystem, PlonkCircuit, Variable,
+    traits::*,
+    PlonkCircuit, Variable,
 };
 
 use super::{PermutationGadget, RescueGadget, SpongeStateVar};
@@ -542,7 +543,7 @@ mod tests {
     use ark_ff::{FftField, PrimeField};
     use ark_std::{vec, vec::Vec};
     use itertools::Itertools;
-    use mpc_relation::{Circuit, ConstraintSystem, PlonkCircuit, Variable};
+    use mpc_relation::{traits::*, PlonkCircuit, Variable};
 
     fn gen_state_matrix_constant<F: PrimeField>(
     ) -> (RescueVector<F>, RescueMatrix<F>, RescueVector<F>) {

--- a/primitives/src/circuit/rescue/non_native.rs
+++ b/primitives/src/circuit/rescue/non_native.rs
@@ -19,7 +19,8 @@ use jf_utils::{compute_len_to_next_multiple, field_switching};
 use mpc_relation::{
     errors::CircuitError::{self, ParameterError},
     gadgets::ultraplonk::mod_arith::{FpElem, FpElemVar},
-    ConstraintSystem, PlonkCircuit,
+    traits::*,
+    PlonkCircuit,
 };
 
 use super::{PermutationGadget, RescueGadget, SpongeStateVar};
@@ -678,7 +679,8 @@ mod tests {
     use jf_utils::field_switching;
     use mpc_relation::{
         gadgets::ultraplonk::mod_arith::{FpElem, FpElemVar},
-        Circuit, PlonkCircuit,
+        traits::*,
+        PlonkCircuit,
     };
 
     const RANGE_BIT_LEN_FOR_TEST: usize = 8;

--- a/primitives/src/circuit/signature/schnorr.rs
+++ b/primitives/src/circuit/signature/schnorr.rs
@@ -23,7 +23,8 @@ use jf_utils::fr_to_fq;
 use mpc_relation::{
     errors::CircuitError,
     gadgets::ecc::{PointVariable, TEPoint},
-    BoolVar, Circuit, ConstraintSystem, PlonkCircuit, Variable,
+    traits::*,
+    BoolVar, PlonkCircuit, Variable,
 };
 
 #[derive(Debug, Clone)]
@@ -203,7 +204,7 @@ mod tests {
     use ark_ed_on_bls12_381::EdwardsConfig as Param381;
     use ark_ed_on_bls12_381_bandersnatch::EdwardsConfig as Param381b;
     use ark_ed_on_bn254::EdwardsConfig as Param254;
-    use mpc_relation::{errors::CircuitError, Circuit, PlonkCircuit, Variable};
+    use mpc_relation::{errors::CircuitError, PlonkCircuit, Variable};
 
     #[test]
     fn test_dsa_circuit() -> Result<(), CircuitError> {

--- a/relation/Cargo.toml
+++ b/relation/Cargo.toml
@@ -13,7 +13,8 @@ ark-bls12-381 = "0.4.0"
 ark-bn254 = "0.4.0"
 ark-bw6-761 = "0.4.0"
 ark-ec = "0.4.0"
-ark-ff = { version = "0.4.0", features = [ "asm" ] }
+ark-ff = { version = "0.4.0", features = ["asm"] }
+ark-mpc = { git = "https://github.com/renegade-fi/ark-mpc.git" }
 ark-poly = "0.4.0"
 ark-serialize = "0.4.0"
 ark-std = { version = "0.4.0", default-features = false }
@@ -36,8 +37,21 @@ ark-ed-on-bn254 = "0.4.0"
 
 [features]
 default = ["parallel"]
-std = ["ark-std/std", "ark-serialize/std", "ark-ff/std", "ark-ec/std", 
-        "ark-poly/std", "downcast-rs/std", "jf-utils/std", "num-bigint/std",
-        "rand_chacha/std"]
-parallel = ["ark-ff/parallel", "ark-ec/parallel", "ark-poly/parallel", 
-            "jf-utils/parallel", "dep:rayon" ]
+std = [
+        "ark-std/std",
+        "ark-serialize/std",
+        "ark-ff/std",
+        "ark-ec/std",
+        "ark-poly/std",
+        "downcast-rs/std",
+        "jf-utils/std",
+        "num-bigint/std",
+        "rand_chacha/std",
+]
+parallel = [
+        "ark-ff/parallel",
+        "ark-ec/parallel",
+        "ark-poly/parallel",
+        "jf-utils/parallel",
+        "dep:rayon",
+]

--- a/relation/src/constraint_system.rs
+++ b/relation/src/constraint_system.rs
@@ -10,8 +10,9 @@ use crate::{
     errors::{CircuitError, CircuitError::*},
     gates::*,
     next_multiple,
+    traits::{Arithmetization, Circuit, ConstraintSystem},
 };
-use ark_ff::{FftField, Field, PrimeField};
+use ark_ff::{FftField, PrimeField};
 use ark_poly::{
     domain::Radix2EvaluationDomain, univariate::DensePolynomial, DenseUVPolynomial,
     EvaluationDomain,
@@ -70,379 +71,6 @@ pub enum MergeableCircuitType {
     TypeB,
 }
 
-/// An interface for Plonk constraint systems.
-pub trait Circuit<F: Field>: ConstraintSystem<F> {
-    /// The number of constraints.
-    fn num_gates(&self) -> usize;
-
-    /// The number of variables.
-    fn num_vars(&self) -> usize;
-
-    /// The number of public input variables.
-    fn num_inputs(&self) -> usize;
-
-    /// The number of wire types of the circuit.
-    /// E.g., UltraPlonk has 4 different types of input wires, 1 type of output
-    /// wires, and 1 type of lookup wires.
-    fn num_wire_types(&self) -> usize;
-
-    /// The list of public input values.
-    fn public_input(&self) -> Result<Vec<F>, CircuitError>;
-
-    /// Check circuit satisfiability against a public input.
-    fn check_circuit_satisfiability(&self, pub_input: &[F]) -> Result<(), CircuitError>;
-
-    /// Add a constant variable to the circuit; return the index of the
-    /// variable.
-    fn create_constant_variable(&mut self, val: F) -> Result<Variable, CircuitError>;
-
-    /// Add a variable to the circuit; return the index of the variable.
-    fn create_variable(&mut self, val: F) -> Result<Variable, CircuitError>;
-
-    /// Add a bool variable to the circuit; return the index of the variable.
-    fn create_boolean_variable(&mut self, val: bool) -> Result<BoolVar, CircuitError> {
-        let val_scalar = if val { F::one() } else { F::zero() };
-        let var = self.create_variable(val_scalar)?;
-        self.enforce_bool(var)?;
-        Ok(BoolVar(var))
-    }
-
-    /// Add a public input variable; return the index of the variable.
-    fn create_public_variable(&mut self, val: F) -> Result<Variable, CircuitError>;
-
-    /// Add a public bool variable to the circuit; return the index of the
-    /// variable.
-    fn create_public_boolean_variable(&mut self, val: bool) -> Result<BoolVar, CircuitError> {
-        let val_scalar = if val { F::one() } else { F::zero() };
-        let var = self.create_public_variable(val_scalar)?;
-        Ok(BoolVar(var))
-    }
-
-    /// Set a variable to a public variable
-    fn set_variable_public(&mut self, var: Variable) -> Result<(), CircuitError>;
-
-    /// Return the witness value of variable `idx`.
-    /// Return error if the input variable is invalid.
-    fn witness(&self, idx: Variable) -> Result<F, CircuitError>;
-}
-
-/// An interface to add gates to a circuit that generalizes across wiring
-/// implementations
-///
-/// Effectively abstracts the variable-centric gate interface
-pub trait ConstraintSystem<F: Field> {
-    /// Return a default variable with value zero.
-    fn zero(&self) -> Variable;
-
-    /// Return a default variable with value one.
-    fn one(&self) -> Variable;
-
-    // -----------
-    // | Boolean |
-    // -----------
-
-    /// Return a default variable with value `false` (namely zero).
-    fn false_var(&self) -> BoolVar {
-        BoolVar::new_unchecked(self.zero())
-    }
-
-    /// Return a default variable with value `true` (namely one).
-    fn true_var(&self) -> BoolVar {
-        BoolVar::new_unchecked(self.one())
-    }
-
-    // --------------
-    // | Arithmetic |
-    // --------------
-
-    /// Constrain variable `c` to the addition of `a` and `b`.
-    /// Return error if the input variables are invalid.
-    fn add_gate(&mut self, a: Variable, b: Variable, c: Variable) -> Result<(), CircuitError>;
-
-    /// Obtain a variable representing an addition.
-    /// Return the index of the variable.
-    /// Return error if the input variables are invalid.
-    fn add(&mut self, a: Variable, b: Variable) -> Result<Variable, CircuitError>;
-
-    /// Constrain variable `c` to the subtraction of `a` and `b`.
-    /// Return error if the input variables are invalid.
-    fn sub_gate(&mut self, a: Variable, b: Variable, c: Variable) -> Result<(), CircuitError>;
-
-    /// Obtain a variable representing a subtraction.
-    /// Return the index of the variable.
-    /// Return error if the input variables are invalid.
-    fn sub(&mut self, a: Variable, b: Variable) -> Result<Variable, CircuitError>;
-
-    /// Constrain variable `c` to the multiplication of `a` and `b`.
-    /// Return error if the input variables are invalid.
-    fn mul_gate(&mut self, a: Variable, b: Variable, c: Variable) -> Result<(), CircuitError>;
-
-    /// Obtain a variable representing a multiplication.
-    /// Return the index of the variable.
-    /// Return error if the input variables are invalid.
-    fn mul(&mut self, a: Variable, b: Variable) -> Result<Variable, CircuitError>;
-
-    /// Constrain a linear combination gate:
-    /// q1 * a + q2 * b + q3 * c + q4 * d  = y
-    fn lc_gate(
-        &mut self,
-        wires: &[Variable; GATE_WIDTH + 1],
-        coeffs: &[F; GATE_WIDTH],
-    ) -> Result<(), CircuitError>;
-
-    /// Obtain a variable representing a linear combination.
-    /// Return error if variables are invalid.
-    fn lc(
-        &mut self,
-        wires_in: &[Variable; GATE_WIDTH],
-        coeffs: &[F; GATE_WIDTH],
-    ) -> Result<Variable, CircuitError>;
-
-    /// Constrain a mul-addition gate:
-    /// q_muls\[0\] * wires\[0\] *  wires\[1\] +  q_muls\[1\] * wires\[2\] *
-    /// wires\[3\] = wires\[4\]
-    fn mul_add_gate(
-        &mut self,
-        wires: &[Variable; GATE_WIDTH + 1],
-        q_muls: &[F; N_MUL_SELECTORS],
-    ) -> Result<(), CircuitError>;
-
-    /// Obtain a variable representing `q12 * a * b + q34 * c * d`,
-    /// where `a, b, c, d` are input wires, and `q12`, `q34` are selectors.
-    /// Return error if variables are invalid.
-    fn mul_add(
-        &mut self,
-        wires_in: &[Variable; GATE_WIDTH],
-        q_muls: &[F; N_MUL_SELECTORS],
-    ) -> Result<Variable, CircuitError>;
-
-    /// Add two values with coefficients `a` and `b`, i.e. `a * x + b * y`
-    fn add_with_coeffs(
-        &mut self,
-        x: Variable,
-        y: Variable,
-        a: &F,
-        b: &F,
-    ) -> Result<Variable, CircuitError> {
-        let one = self.one();
-        self.mul_add(&[x, one, y, one], &[*a, *b])
-    }
-
-    /// Multiply two values with an added coefficient `c`
-    ///
-    /// I.e. for variables x, y and constant c we compute c * x * y
-    fn mul_with_coeff(
-        &mut self,
-        a: Variable,
-        b: Variable,
-        c: &F,
-    ) -> Result<Variable, CircuitError> {
-        let zero = self.zero();
-        self.mul_add(&[a, b, zero, zero], &[*c, F::zero()])
-    }
-
-    /// Obtain a variable representing the sum of a list of variables.
-    /// Return error if variables are invalid.
-    fn sum(&mut self, elems: &[Variable]) -> Result<Variable, CircuitError>;
-
-    /// Sum a vector of variables with given coefficients
-    fn lc_sum(&mut self, elems: &[Variable], coeffs: &[F]) -> Result<Variable, CircuitError> {
-        assert_eq!(elems.len(), coeffs.len());
-
-        // Create partial linear combinations then sum them
-        let mut partials = Vec::new();
-
-        let n_lcs = next_multiple(elems.len(), GATE_WIDTH)?;
-        let mut padded_wires = elems.to_vec();
-        let mut padded_coeffs = coeffs.to_vec();
-
-        padded_wires.resize(n_lcs, self.zero());
-        padded_coeffs.resize(n_lcs, F::zero());
-
-        for (wires, coeffs) in padded_wires
-            .chunks(GATE_WIDTH)
-            .zip(padded_coeffs.chunks(GATE_WIDTH))
-        {
-            partials.push(self.lc(
-                &[wires[0], wires[1], wires[2], wires[3]],
-                &[coeffs[0], coeffs[1], coeffs[2], coeffs[3]],
-            )?);
-        }
-
-        self.sum(&partials)
-    }
-
-    /// Constrain variable `y` to the addition of `a` and `c`, where `c` is a
-    /// constant value Return error if the input variables are invalid.
-    fn add_constant_gate(&mut self, x: Variable, c: F, y: Variable) -> Result<(), CircuitError>;
-
-    /// Obtains a variable representing an addition with a constant value
-    /// Return error if the input variable is invalid
-    fn add_constant(&mut self, input_var: Variable, elem: &F) -> Result<Variable, CircuitError>;
-
-    /// Constrain variable `y` to the product of `a` and `c`, where `c` is a
-    /// constant value Return error if the input variables are invalid.
-    fn mul_constant_gate(&mut self, x: Variable, c: F, y: Variable) -> Result<(), CircuitError>;
-
-    /// Obtains a variable representing a multiplication with a constant value
-    /// Return error if the input variable is invalid
-    fn mul_constant(&mut self, input_var: Variable, elem: &F) -> Result<Variable, CircuitError>;
-
-    /// Takes the input to the fifth power
-    fn pow5(&mut self, x: Variable) -> Result<Variable, CircuitError>;
-
-    // ---------------
-    // | Logic Gates |
-    // ---------------
-
-    /// Constrains variable `c` to be `if sel { a } else b`
-    fn mux_gate(
-        &mut self,
-        sel: BoolVar,
-        a: Variable,
-        b: Variable,
-        c: Variable,
-    ) -> Result<(), CircuitError>;
-
-    /// Create a variable representation of `if sel { a } else { b }`
-    fn mux(&mut self, sel: BoolVar, a: Variable, b: Variable) -> Result<Variable, CircuitError>;
-
-    // ---------------
-    // | Constraints |
-    // ---------------
-
-    /// Common gates that should be implemented in any constraint systems.
-    ///
-    /// Constrain a variable to a constant.
-    /// Return error if `var` is an invalid variable.
-    fn enforce_constant(&mut self, var: Variable, constant: F) -> Result<(), CircuitError>;
-
-    /// Constrain a variable to a bool.
-    /// Return error if the input is invalid.
-    fn enforce_bool(&mut self, a: Variable) -> Result<(), CircuitError>;
-
-    /// Constrain two variables to have the same value.
-    /// Return error if the input variables are invalid.
-    fn enforce_equal(&mut self, a: Variable, b: Variable) -> Result<(), CircuitError>;
-
-    /// Pad the circuit with n dummy gates
-    fn pad_gates(&mut self, n: usize);
-
-    /// Plookup-related methods.
-    /// Return true if the circuit support lookup gates.
-    fn support_lookup(&self) -> bool;
-}
-
-// The sorted concatenation of the lookup table and the witness values to be
-// checked in lookup gates. It also includes 2 polynomials that interpolate the
-// sorted vector.
-pub(crate) type SortedLookupVecAndPolys<F> = (Vec<F>, DensePolynomial<F>, DensePolynomial<F>);
-
-/// An interface that transforms Plonk circuits to polynomial used by
-/// Plonk-based SNARKs.
-pub trait Arithmetization<F: FftField>: Circuit<F> {
-    /// The required SRS size for the circuit.
-    fn srs_size(&self) -> Result<usize, CircuitError>;
-
-    /// Get the size of the evaluation domain for arithmetization (after circuit
-    /// has been finalized).
-    fn eval_domain_size(&self) -> Result<usize, CircuitError>;
-
-    /// Compute and return selector polynomials.
-    /// Return an error if the circuit has not been finalized yet.
-    fn compute_selector_polynomials(&self) -> Result<Vec<DensePolynomial<F>>, CircuitError>;
-
-    /// Compute and return extended permutation polynomials.
-    /// Return an error if the circuit has not been finalized yet.
-    fn compute_extended_permutation_polynomials(
-        &self,
-    ) -> Result<Vec<DensePolynomial<F>>, CircuitError>;
-
-    /// Compute and return the product polynomial for permutation arguments.
-    /// Return an error if the circuit has not been finalized yet.
-    fn compute_prod_permutation_polynomial(
-        &self,
-        beta: &F,
-        gamma: &F,
-    ) -> Result<DensePolynomial<F>, CircuitError>;
-
-    /// Compute and return the list of wiring witness polynomials.
-    /// Return an error if the circuit has not been finalized yet.
-    fn compute_wire_polynomials(&self) -> Result<Vec<DensePolynomial<F>>, CircuitError>;
-
-    /// Compute and return the public input polynomial.
-    /// Return an error if the circuit has not been finalized yet.
-    /// The IO gates of the circuit are guaranteed to be in the front.
-    fn compute_pub_input_polynomial(&self) -> Result<DensePolynomial<F>, CircuitError>;
-
-    /// Plookup-related methods
-    /// Return default errors if the constraint system does not support lookup
-    /// gates.
-    ///
-    /// Compute and return the polynomial that interpolates the range table
-    /// elements. Return an error if the circuit does not support lookup or
-    /// has not been finalized yet.
-    fn compute_range_table_polynomial(&self) -> Result<DensePolynomial<F>, CircuitError> {
-        Err(CircuitError::LookupUnsupported)
-    }
-
-    /// Compute and return the polynomial that interpolates the key table
-    /// elements. Return an error if the circuit does not support lookup or
-    /// has not been finalized yet.
-    fn compute_key_table_polynomial(&self) -> Result<DensePolynomial<F>, CircuitError> {
-        Err(CircuitError::LookupUnsupported)
-    }
-
-    /// Compute and return the polynomial that interpolates the table domain
-    /// sepration ids. Return an error if the circuit does not support
-    /// lookup or has not been finalized.
-    fn compute_table_dom_sep_polynomial(&self) -> Result<DensePolynomial<F>, CircuitError> {
-        Err(CircuitError::LookupUnsupported)
-    }
-
-    /// Compute and return the polynomial that interpolates the lookup domain
-    /// sepration selectors for the lookup gates. Return an error if the
-    /// circuit does not support lookup or has not been finalized.
-    fn compute_q_dom_sep_polynomial(&self) -> Result<DensePolynomial<F>, CircuitError> {
-        Err(CircuitError::LookupUnsupported)
-    }
-
-    /// Compute and return the combined lookup table vector given random
-    /// challenge `tau`.
-    fn compute_merged_lookup_table(&self, _tau: F) -> Result<Vec<F>, CircuitError> {
-        Err(CircuitError::LookupUnsupported)
-    }
-
-    /// Compute the sorted concatenation of the (merged) lookup table and the
-    /// witness values to be checked in lookup gates. Return the sorted
-    /// vector and 2 polynomials that interpolate the vector. Return an
-    /// error if the circuit does not support lookup or has not been
-    /// finalized yet.
-    fn compute_lookup_sorted_vec_polynomials(
-        &self,
-        _tau: F,
-        _lookup_table: &[F],
-    ) -> Result<SortedLookupVecAndPolys<F>, CircuitError> {
-        Err(CircuitError::LookupUnsupported)
-    }
-
-    /// Compute and return the product polynomial for Plookup arguments.
-    /// `beta` and `gamma` are random challenges, `sorted_vec` is the sorted
-    /// concatenation of the lookup table and the lookup witnesses.
-    /// Return an error if the circuit does not support lookup or
-    /// has not been finalized yet.
-    fn compute_lookup_prod_polynomial(
-        &self,
-        _tau: &F,
-        _beta: &F,
-        _gamma: &F,
-        _lookup_table: &[F],
-        _sorted_vec: &[F],
-    ) -> Result<DensePolynomial<F>, CircuitError> {
-        Err(CircuitError::LookupUnsupported)
-    }
-}
-
 /// The wire type identifier for range gates.
 const RANGE_WIRE_ID: usize = 5;
 /// The wire type identifier for the key index in a lookup gate
@@ -484,6 +112,11 @@ impl PlonkParams {
         })
     }
 }
+
+// The sorted concatenation of the lookup table and the witness values to be
+// checked in lookup gates. It also includes 2 polynomials that interpolate the
+// sorted vector.
+pub(crate) type SortedLookupVecAndPolys<F> = (Vec<F>, DensePolynomial<F>, DensePolynomial<F>);
 
 /// A specific Plonk circuit instantiation.
 #[derive(Debug, Clone)]
@@ -588,28 +221,6 @@ impl<F: FftField> PlonkCircuit<F> {
     pub fn new_ultra_plonk(range_bit_len: usize) -> Self {
         let plonk_params = PlonkParams::init(PlonkType::UltraPlonk, Some(range_bit_len)).unwrap(); // safe unwrap
         Self::new(plonk_params)
-    }
-
-    /// Insert a general (algebraic) gate
-    /// * `wire_vars` - wire variables. Each of these variables must be in range
-    /// * `gate` - specific gate to be inserted
-    /// * `returns` - an error if some verification fails
-    pub fn insert_gate(
-        &mut self,
-        wire_vars: &[Variable; GATE_WIDTH + 1],
-        gate: Box<dyn Gate<F>>,
-    ) -> Result<(), CircuitError> {
-        self.check_finalize_flag(false)?;
-
-        for (wire_var, wire_variable) in wire_vars
-            .iter()
-            .zip(self.wire_variables.iter_mut().take(GATE_WIDTH + 1))
-        {
-            wire_variable.push(*wire_var)
-        }
-
-        self.gates.push(gate);
-        Ok(())
     }
 
     /// Add a range_check gate that checks whether a variable is in the range
@@ -843,6 +454,28 @@ impl<F: FftField> ConstraintSystem<F> for PlonkCircuit<F> {
     /// Default one variable
     fn one(&self) -> Variable {
         1
+    }
+
+    /// Insert a general (algebraic) gate
+    /// * `wire_vars` - wire variables. Each of these variables must be in range
+    /// * `gate` - specific gate to be inserted
+    /// * `returns` - an error if some verification fails
+    fn insert_gate(
+        &mut self,
+        wire_vars: &[Variable; GATE_WIDTH + 1],
+        gate: Box<dyn Gate<F>>,
+    ) -> Result<(), CircuitError> {
+        self.check_finalize_flag(false)?;
+
+        for (wire_var, wire_variable) in wire_vars
+            .iter()
+            .zip(self.wire_variables.iter_mut().take(GATE_WIDTH + 1))
+        {
+            wire_variable.push(*wire_var)
+        }
+
+        self.gates.push(gate);
+        Ok(())
     }
 
     fn enforce_constant(&mut self, var: Variable, constant: F) -> Result<(), CircuitError> {

--- a/relation/src/gadgets/arithmetic.rs
+++ b/relation/src/gadgets/arithmetic.rs
@@ -10,7 +10,8 @@ use crate::{
     constants::{GATE_WIDTH, N_MUL_SELECTORS},
     errors::CircuitError,
     gates::{FifthRootGate, QuadPolyGate},
-    Circuit, ConstraintSystem, PlonkCircuit, Variable,
+    traits::*,
+    PlonkCircuit, Variable,
 };
 use ark_ff::PrimeField;
 use ark_std::{boxed::Box, string::ToString};
@@ -298,8 +299,7 @@ impl<F: PrimeField> PlonkCircuit<F> {
 mod test {
     use crate::{
         constants::GATE_WIDTH, errors::CircuitError,
-        gadgets::test_utils::test_variable_independence_for_circuit, Circuit, ConstraintSystem,
-        PlonkCircuit,
+        gadgets::test_utils::test_variable_independence_for_circuit, traits::*, PlonkCircuit,
     };
     use ark_bls12_377::Fq as Fq377;
     use ark_ed_on_bls12_377::Fq as FqEd377;

--- a/relation/src/gadgets/cmp.rs
+++ b/relation/src/gadgets/cmp.rs
@@ -6,7 +6,7 @@
 
 //! Comparison gadgets for circuit
 
-use crate::{errors::CircuitError, BoolVar, Circuit, ConstraintSystem, PlonkCircuit, Variable};
+use crate::{errors::CircuitError, traits::*, BoolVar, PlonkCircuit, Variable};
 use ark_ff::{BigInteger, PrimeField};
 
 impl<F: PrimeField> PlonkCircuit<F> {
@@ -254,7 +254,7 @@ impl<F: PrimeField> PlonkCircuit<F> {
 
 #[cfg(test)]
 mod test {
-    use crate::{errors::CircuitError, BoolVar, Circuit, PlonkCircuit};
+    use crate::{errors::CircuitError, traits::*, BoolVar, PlonkCircuit};
     use ark_bls12_377::Fq as Fq377;
     use ark_ed_on_bls12_377::Fq as FqEd377;
     use ark_ed_on_bls12_381::Fq as FqEd381;

--- a/relation/src/gadgets/ecc/emulated/short_weierstrass.rs
+++ b/relation/src/gadgets/ecc/emulated/short_weierstrass.rs
@@ -9,7 +9,8 @@
 use crate::{
     errors::CircuitError,
     gadgets::{from_emulated_field, EmulatedVariable, EmulationConfig, SerializableEmulatedStruct},
-    BoolVar, Circuit, ConstraintSystem, PlonkCircuit,
+    traits::*,
+    BoolVar, PlonkCircuit,
 };
 use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
 use ark_ff::PrimeField;
@@ -334,7 +335,8 @@ mod tests {
     use crate::{
         errors::CircuitError,
         gadgets::{ecc::conversion::*, EmulationConfig, SerializableEmulatedStruct},
-        Circuit, PlonkCircuit,
+        traits::*,
+        PlonkCircuit,
     };
     use ark_bls12_377::{g1::Config as Param377, Fq as Fq377};
     use ark_bn254::{g1::Config as Param254, Fq as Fq254, Fr as Fr254};

--- a/relation/src/gadgets/ecc/emulated/twisted_edwards.rs
+++ b/relation/src/gadgets/ecc/emulated/twisted_edwards.rs
@@ -9,7 +9,8 @@
 use crate::{
     errors::CircuitError,
     gadgets::{ecc::TEPoint, EmulatedVariable, EmulationConfig},
-    BoolVar, ConstraintSystem, PlonkCircuit,
+    traits::*,
+    BoolVar, PlonkCircuit,
 };
 use ark_ff::PrimeField;
 
@@ -160,7 +161,8 @@ mod tests {
             ecc::{conversion::*, TEPoint},
             EmulationConfig,
         },
-        Circuit, PlonkCircuit,
+        traits::*,
+        PlonkCircuit,
     };
     use ark_bls12_377::{g1::Config as Param377, Fq as Fq377};
     use ark_bn254::Fr as Fr254;

--- a/relation/src/gadgets/ecc/glv.rs
+++ b/relation/src/gadgets/ecc/glv.rs
@@ -7,7 +7,8 @@
 use crate::{
     errors::CircuitError,
     gadgets::ecc::{MultiScalarMultiplicationCircuit, PointVariable},
-    BoolVar, Circuit, ConstraintSystem, PlonkCircuit, Variable,
+    traits::*,
+    BoolVar, PlonkCircuit, Variable,
 };
 use ark_ec::{
     twisted_edwards::{Projective, TECurveConfig},
@@ -571,7 +572,7 @@ fn get_bits(a: &[bool]) -> u16 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{errors::CircuitError, gadgets::ecc::TEPoint, Circuit, PlonkCircuit};
+    use crate::{errors::CircuitError, gadgets::ecc::TEPoint, PlonkCircuit};
     use ark_ec::{
         twisted_edwards::{Affine, TECurveConfig as Config},
         CurveConfig,

--- a/relation/src/gadgets/ecc/mod.rs
+++ b/relation/src/gadgets/ecc/mod.rs
@@ -8,9 +8,7 @@
 //! non-native fields.
 
 use super::{from_emulated_field, EmulationConfig, SerializableEmulatedStruct};
-use crate::{
-    errors::CircuitError, gates::*, BoolVar, Circuit, ConstraintSystem, PlonkCircuit, Variable,
-};
+use crate::{errors::CircuitError, gates::*, traits::*, BoolVar, PlonkCircuit, Variable};
 use ark_ec::{
     twisted_edwards::{Affine, Projective, TECurveConfig as Config},
     AffineRepr, CurveConfig, CurveGroup, ScalarMul,
@@ -598,7 +596,7 @@ fn compute_base_points<E: ScalarMul>(base: &E, len: usize) -> Result<[Vec<E>; 3]
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{gadgets::test_utils::test_variable_independence_for_circuit, Circuit};
+    use crate::gadgets::test_utils::test_variable_independence_for_circuit;
     use ark_bls12_377::{g1::Config as Param761, Fq as Fq377};
     use ark_ec::{twisted_edwards::TECurveConfig as Config, Group};
     use ark_ed_on_bls12_377::{EdwardsConfig as Param377, Fq as FqEd377};

--- a/relation/src/gadgets/ecc/msm.rs
+++ b/relation/src/gadgets/ecc/msm.rs
@@ -7,7 +7,7 @@
 //! This module implements multi-scalar-multiplication circuits.
 
 use super::{PointVariable, TEPoint};
-use crate::{errors::CircuitError, Circuit, ConstraintSystem, PlonkCircuit, Variable};
+use crate::{errors::CircuitError, traits::*, PlonkCircuit, Variable};
 use ark_ec::{
     twisted_edwards::{Projective, TECurveConfig as Config},
     CurveConfig,
@@ -368,7 +368,7 @@ fn ln_without_floats(a: usize) -> usize {
 mod tests {
 
     use super::*;
-    use crate::{gadgets::ecc::TEPoint, Circuit, PlonkType};
+    use crate::{gadgets::ecc::TEPoint, PlonkType};
     use ark_bls12_377::{g1::Config as Param377, Fq as Fq377};
     use ark_ec::{
         scalar_mul::variable_base::VariableBaseMSM,

--- a/relation/src/gadgets/emulated.rs
+++ b/relation/src/gadgets/emulated.rs
@@ -12,7 +12,7 @@
 //! componenet, with modulus 2^T, will be divided into limbs each with B bits
 //! where 2^{2B} < p.
 
-use crate::{errors::CircuitError, BoolVar, Circuit, ConstraintSystem, PlonkCircuit, Variable};
+use crate::{errors::CircuitError, traits::*, BoolVar, PlonkCircuit, Variable};
 use ark_ff::PrimeField;
 use ark_std::{string::ToString, vec, vec::Vec, One, Zero};
 use core::marker::PhantomData;
@@ -707,7 +707,7 @@ impl EmulationConfig<ark_bn254::Fr> for ark_bn254::Fq {
 #[cfg(test)]
 mod tests {
     use super::EmulationConfig;
-    use crate::{gadgets::from_emulated_field, Circuit, PlonkCircuit};
+    use crate::{gadgets::from_emulated_field, traits::*, PlonkCircuit};
     use ark_bls12_377::Fq as Fq377;
     use ark_bn254::{Fq as Fq254, Fr as Fr254};
     use ark_ff::{MontFp, PrimeField};

--- a/relation/src/gadgets/logic.rs
+++ b/relation/src/gadgets/logic.rs
@@ -9,7 +9,8 @@
 use crate::{
     errors::CircuitError,
     gates::{CondSelectGate, LogicOrGate, LogicOrOutputGate},
-    BoolVar, Circuit, ConstraintSystem, PlonkCircuit, Variable,
+    traits::*,
+    BoolVar, PlonkCircuit, Variable,
 };
 use ark_ff::PrimeField;
 use ark_std::{boxed::Box, string::ToString};
@@ -168,8 +169,8 @@ impl<F: PrimeField> PlonkCircuit<F> {
 #[cfg(test)]
 mod test {
     use crate::{
-        errors::CircuitError, gadgets::test_utils::test_variable_independence_for_circuit, Circuit,
-        ConstraintSystem, PlonkCircuit,
+        errors::CircuitError, gadgets::test_utils::test_variable_independence_for_circuit,
+        traits::*, PlonkCircuit,
     };
     use ark_bls12_377::Fq as Fq377;
     use ark_ed_on_bls12_377::Fq as FqEd377;

--- a/relation/src/gadgets/mod.rs
+++ b/relation/src/gadgets/mod.rs
@@ -22,7 +22,7 @@ pub use range::*;
 
 /// Utils for test
 pub mod test_utils {
-    use crate::{errors::CircuitError, Arithmetization, Circuit, PlonkCircuit};
+    use crate::{errors::CircuitError, traits::*, PlonkCircuit};
     use ark_ff::PrimeField;
 
     /// two circuit with the same statement should have the same extended

--- a/relation/src/gadgets/range.rs
+++ b/relation/src/gadgets/range.rs
@@ -7,8 +7,8 @@
 //! Implemtation of circuit lookup related gadgets
 
 use crate::{
-    constants::GATE_WIDTH, errors::CircuitError, next_multiple, BoolVar, Circuit, ConstraintSystem,
-    PlonkCircuit, Variable,
+    constants::GATE_WIDTH, errors::CircuitError, next_multiple, traits::*, BoolVar, PlonkCircuit,
+    Variable,
 };
 use ark_ff::{BigInteger, PrimeField};
 use ark_std::{format, string::ToString, vec::Vec};
@@ -144,8 +144,8 @@ impl<F: PrimeField> PlonkCircuit<F> {
 #[cfg(test)]
 mod test {
     use crate::{
-        errors::CircuitError, gadgets::test_utils::test_variable_independence_for_circuit, Circuit,
-        PlonkCircuit,
+        errors::CircuitError, gadgets::test_utils::test_variable_independence_for_circuit,
+        traits::*, PlonkCircuit,
     };
     use ark_bls12_377::Fq as Fq377;
     use ark_ed_on_bls12_377::Fq as FqEd377;

--- a/relation/src/gadgets/ultraplonk/lookup_table.rs
+++ b/relation/src/gadgets/ultraplonk/lookup_table.rs
@@ -6,9 +6,7 @@
 
 //! Lookup gates over variable tables.
 
-use crate::{
-    errors::CircuitError, gates::LookupGate, Circuit, ConstraintSystem, PlonkCircuit, Variable,
-};
+use crate::{errors::CircuitError, gates::LookupGate, traits::*, PlonkCircuit, Variable};
 use ark_ff::PrimeField;
 use ark_std::{boxed::Box, cmp::max};
 

--- a/relation/src/gadgets/ultraplonk/mod_arith.rs
+++ b/relation/src/gadgets/ultraplonk/mod_arith.rs
@@ -8,7 +8,9 @@
 use crate::{
     constants::GATE_WIDTH,
     errors::CircuitError::{self, ParameterError},
-    next_multiple, Circuit, ConstraintSystem, PlonkCircuit, Variable,
+    next_multiple,
+    traits::*,
+    PlonkCircuit, Variable,
 };
 use ark_ff::PrimeField;
 use ark_std::{format, string::ToString, vec, vec::Vec};

--- a/relation/src/gadgets/ultraplonk/non_native_gates.rs
+++ b/relation/src/gadgets/ultraplonk/non_native_gates.rs
@@ -8,7 +8,7 @@
 //! useful for rescue hash function.
 
 use super::mod_arith::{FpElem, FpElemVar};
-use crate::{errors::CircuitError, ConstraintSystem, PlonkCircuit};
+use crate::{errors::CircuitError, traits::*, PlonkCircuit};
 use ark_ff::{BigInteger, PrimeField};
 use ark_std::{format, vec::Vec};
 
@@ -197,7 +197,7 @@ impl<F: PrimeField> PlonkCircuit<F> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{Circuit, Variable};
+    use crate::Variable;
     use ark_bls12_377::Fq as Fq377;
     use ark_ed_on_bls12_377::Fq as FqEd377;
     use jf_utils::test_rng;

--- a/relation/src/gadgets/ultraplonk/range.rs
+++ b/relation/src/gadgets/ultraplonk/range.rs
@@ -7,7 +7,8 @@
 //! Range proof gates.
 use crate::{
     errors::CircuitError::{self, ParameterError},
-    Circuit, PlonkCircuit, Variable,
+    traits::*,
+    PlonkCircuit, Variable,
 };
 use ark_ff::{BigInteger, PrimeField};
 use ark_std::{string::ToString, vec::Vec};
@@ -87,14 +88,13 @@ fn decompose_le<F: PrimeField>(val: F, len: usize, range_bit_len: usize) -> Vec<
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::traits::ConstraintSystem;
     use ark_bls12_377::Fq as Fq377;
     use ark_ed_on_bls12_377::Fq as FqEd377;
     use ark_ed_on_bls12_381::Fq as FqEd381;
     use ark_ed_on_bn254::Fq as FqEd254;
     use ark_std::rand::Rng;
     use jf_utils::test_rng;
-
-    use crate::ConstraintSystem;
 
     const RANGE_BIT_LEN_FOR_TEST: usize = 8;
     const RANGE_SIZE_FOR_TEST: usize = 256;

--- a/relation/src/lib.rs
+++ b/relation/src/lib.rs
@@ -12,6 +12,7 @@ pub mod constants;
 pub mod errors;
 pub mod gadgets;
 pub mod gates;
+pub mod traits;
 
 pub mod constraint_system;
 use core::cmp::Ordering;

--- a/relation/src/traits.rs
+++ b/relation/src/traits.rs
@@ -1,0 +1,388 @@
+//! Defines traits for expressing a Plonk relation
+
+use core::ops::{Add, Mul, Neg, Sub};
+
+use ark_ff::{FftField, Field};
+use ark_poly::univariate::DensePolynomial;
+
+use crate::{
+    constants::{GATE_WIDTH, N_MUL_SELECTORS},
+    errors::CircuitError,
+    gates::Gate,
+    next_multiple, BoolVar, SortedLookupVecAndPolys, Variable,
+};
+
+/// An interface for Plonk constraint systems.
+pub trait Circuit<F: Field>: ConstraintSystem<F> {
+    /// The number of constraints.
+    fn num_gates(&self) -> usize;
+
+    /// The number of variables.
+    fn num_vars(&self) -> usize;
+
+    /// The number of public input variables.
+    fn num_inputs(&self) -> usize;
+
+    /// The number of wire types of the circuit.
+    /// E.g., UltraPlonk has 4 different types of input wires, 1 type of output
+    /// wires, and 1 type of lookup wires.
+    fn num_wire_types(&self) -> usize;
+
+    /// The list of public input values.
+    fn public_input(&self) -> Result<Vec<F>, CircuitError>;
+
+    /// Check circuit satisfiability against a public input.
+    fn check_circuit_satisfiability(&self, pub_input: &[F]) -> Result<(), CircuitError>;
+
+    /// Add a constant variable to the circuit; return the index of the
+    /// variable.
+    fn create_constant_variable(&mut self, val: F) -> Result<Variable, CircuitError>;
+
+    /// Add a variable to the circuit; return the index of the variable.
+    fn create_variable(&mut self, val: F) -> Result<Variable, CircuitError>;
+
+    /// Add a bool variable to the circuit; return the index of the variable.
+    fn create_boolean_variable(&mut self, val: bool) -> Result<BoolVar, CircuitError> {
+        let val_scalar = if val { F::one() } else { F::zero() };
+        let var = self.create_variable(val_scalar)?;
+        self.enforce_bool(var)?;
+        Ok(BoolVar(var))
+    }
+
+    /// Add a public input variable; return the index of the variable.
+    fn create_public_variable(&mut self, val: F) -> Result<Variable, CircuitError>;
+
+    /// Add a public bool variable to the circuit; return the index of the
+    /// variable.
+    fn create_public_boolean_variable(&mut self, val: bool) -> Result<BoolVar, CircuitError> {
+        let val_scalar = if val { F::one() } else { F::zero() };
+        let var = self.create_public_variable(val_scalar)?;
+        Ok(BoolVar(var))
+    }
+
+    /// Set a variable to a public variable
+    fn set_variable_public(&mut self, var: Variable) -> Result<(), CircuitError>;
+
+    /// Return the witness value of variable `idx`.
+    /// Return error if the input variable is invalid.
+    fn witness(&self, idx: Variable) -> Result<F, CircuitError>;
+}
+
+/// An interface to add gates to a circuit that generalizes across wiring
+/// implementations
+///
+/// Effectively abstracts the variable-centric gate interface
+pub trait ConstraintSystem<F: Field> {
+    /// Return a default variable with value zero.
+    fn zero(&self) -> Variable;
+
+    /// Return a default variable with value one.
+    fn one(&self) -> Variable;
+
+    /// Insert a gate into the constraint system
+    fn insert_gate(
+        &mut self,
+        wire_vars: &[Variable; GATE_WIDTH + 1],
+        gate: Box<dyn Gate<F>>,
+    ) -> Result<(), CircuitError>;
+
+    // -----------
+    // | Boolean |
+    // -----------
+
+    /// Return a default variable with value `false` (namely zero).
+    fn false_var(&self) -> BoolVar {
+        BoolVar::new_unchecked(self.zero())
+    }
+
+    /// Return a default variable with value `true` (namely one).
+    fn true_var(&self) -> BoolVar {
+        BoolVar::new_unchecked(self.one())
+    }
+
+    // --------------
+    // | Arithmetic |
+    // --------------
+
+    /// Constrain variable `c` to the addition of `a` and `b`.
+    /// Return error if the input variables are invalid.
+    fn add_gate(&mut self, a: Variable, b: Variable, c: Variable) -> Result<(), CircuitError>;
+
+    /// Obtain a variable representing an addition.
+    /// Return the index of the variable.
+    /// Return error if the input variables are invalid.
+    fn add(&mut self, a: Variable, b: Variable) -> Result<Variable, CircuitError>;
+
+    /// Constrain variable `c` to the subtraction of `a` and `b`.
+    /// Return error if the input variables are invalid.
+    fn sub_gate(&mut self, a: Variable, b: Variable, c: Variable) -> Result<(), CircuitError>;
+
+    /// Obtain a variable representing a subtraction.
+    /// Return the index of the variable.
+    /// Return error if the input variables are invalid.
+    fn sub(&mut self, a: Variable, b: Variable) -> Result<Variable, CircuitError>;
+
+    /// Constrain variable `c` to the multiplication of `a` and `b`.
+    /// Return error if the input variables are invalid.
+    fn mul_gate(&mut self, a: Variable, b: Variable, c: Variable) -> Result<(), CircuitError>;
+
+    /// Obtain a variable representing a multiplication.
+    /// Return the index of the variable.
+    /// Return error if the input variables are invalid.
+    fn mul(&mut self, a: Variable, b: Variable) -> Result<Variable, CircuitError>;
+
+    /// Constrain a linear combination gate:
+    /// q1 * a + q2 * b + q3 * c + q4 * d  = y
+    fn lc_gate(
+        &mut self,
+        wires: &[Variable; GATE_WIDTH + 1],
+        coeffs: &[F; GATE_WIDTH],
+    ) -> Result<(), CircuitError>;
+
+    /// Obtain a variable representing a linear combination.
+    /// Return error if variables are invalid.
+    fn lc(
+        &mut self,
+        wires_in: &[Variable; GATE_WIDTH],
+        coeffs: &[F; GATE_WIDTH],
+    ) -> Result<Variable, CircuitError>;
+
+    /// Constrain a mul-addition gate:
+    /// q_muls\[0\] * wires\[0\] *  wires\[1\] +  q_muls\[1\] * wires\[2\] *
+    /// wires\[3\] = wires\[4\]
+    fn mul_add_gate(
+        &mut self,
+        wires: &[Variable; GATE_WIDTH + 1],
+        q_muls: &[F; N_MUL_SELECTORS],
+    ) -> Result<(), CircuitError>;
+
+    /// Obtain a variable representing `q12 * a * b + q34 * c * d`,
+    /// where `a, b, c, d` are input wires, and `q12`, `q34` are selectors.
+    /// Return error if variables are invalid.
+    fn mul_add(
+        &mut self,
+        wires_in: &[Variable; GATE_WIDTH],
+        q_muls: &[F; N_MUL_SELECTORS],
+    ) -> Result<Variable, CircuitError>;
+
+    /// Add two values with coefficients `a` and `b`, i.e. `a * x + b * y`
+    fn add_with_coeffs(
+        &mut self,
+        x: Variable,
+        y: Variable,
+        a: &F,
+        b: &F,
+    ) -> Result<Variable, CircuitError> {
+        let one = self.one();
+        self.mul_add(&[x, one, y, one], &[*a, *b])
+    }
+
+    /// Multiply two values with an added coefficient `c`
+    ///
+    /// I.e. for variables x, y and constant c we compute c * x * y
+    fn mul_with_coeff(
+        &mut self,
+        a: Variable,
+        b: Variable,
+        c: &F,
+    ) -> Result<Variable, CircuitError> {
+        let zero = self.zero();
+        self.mul_add(&[a, b, zero, zero], &[*c, F::zero()])
+    }
+
+    /// Obtain a variable representing the sum of a list of variables.
+    /// Return error if variables are invalid.
+    fn sum(&mut self, elems: &[Variable]) -> Result<Variable, CircuitError>;
+
+    /// Sum a vector of variables with given coefficients
+    fn lc_sum(&mut self, elems: &[Variable], coeffs: &[F]) -> Result<Variable, CircuitError> {
+        assert_eq!(elems.len(), coeffs.len());
+
+        // Create partial linear combinations then sum them
+        let mut partials = Vec::new();
+
+        let n_lcs = next_multiple(elems.len(), GATE_WIDTH)?;
+        let mut padded_wires = elems.to_vec();
+        let mut padded_coeffs = coeffs.to_vec();
+
+        padded_wires.resize(n_lcs, self.zero());
+        padded_coeffs.resize(n_lcs, F::zero());
+
+        for (wires, coeffs) in padded_wires
+            .chunks(GATE_WIDTH)
+            .zip(padded_coeffs.chunks(GATE_WIDTH))
+        {
+            partials.push(self.lc(
+                &[wires[0], wires[1], wires[2], wires[3]],
+                &[coeffs[0], coeffs[1], coeffs[2], coeffs[3]],
+            )?);
+        }
+
+        self.sum(&partials)
+    }
+
+    /// Constrain variable `y` to the addition of `a` and `c`, where `c` is a
+    /// constant value Return error if the input variables are invalid.
+    fn add_constant_gate(&mut self, x: Variable, c: F, y: Variable) -> Result<(), CircuitError>;
+
+    /// Obtains a variable representing an addition with a constant value
+    /// Return error if the input variable is invalid
+    fn add_constant(&mut self, input_var: Variable, elem: &F) -> Result<Variable, CircuitError>;
+
+    /// Constrain variable `y` to the product of `a` and `c`, where `c` is a
+    /// constant value Return error if the input variables are invalid.
+    fn mul_constant_gate(&mut self, x: Variable, c: F, y: Variable) -> Result<(), CircuitError>;
+
+    /// Obtains a variable representing a multiplication with a constant value
+    /// Return error if the input variable is invalid
+    fn mul_constant(&mut self, input_var: Variable, elem: &F) -> Result<Variable, CircuitError>;
+
+    /// Takes the input to the fifth power
+    fn pow5(&mut self, x: Variable) -> Result<Variable, CircuitError>;
+
+    // ---------------
+    // | Logic Gates |
+    // ---------------
+
+    /// Constrains variable `c` to be `if sel { a } else b`
+    fn mux_gate(
+        &mut self,
+        sel: BoolVar,
+        a: Variable,
+        b: Variable,
+        c: Variable,
+    ) -> Result<(), CircuitError>;
+
+    /// Create a variable representation of `if sel { a } else { b }`
+    fn mux(&mut self, sel: BoolVar, a: Variable, b: Variable) -> Result<Variable, CircuitError>;
+
+    // ---------------
+    // | Constraints |
+    // ---------------
+
+    /// Common gates that should be implemented in any constraint systems.
+    ///
+    /// Constrain a variable to a constant.
+    /// Return error if `var` is an invalid variable.
+    fn enforce_constant(&mut self, var: Variable, constant: F) -> Result<(), CircuitError>;
+
+    /// Constrain a variable to a bool.
+    /// Return error if the input is invalid.
+    fn enforce_bool(&mut self, a: Variable) -> Result<(), CircuitError>;
+
+    /// Constrain two variables to have the same value.
+    /// Return error if the input variables are invalid.
+    fn enforce_equal(&mut self, a: Variable, b: Variable) -> Result<(), CircuitError>;
+
+    /// Pad the circuit with n dummy gates
+    fn pad_gates(&mut self, n: usize);
+
+    /// Plookup-related methods.
+    /// Return true if the circuit support lookup gates.
+    fn support_lookup(&self) -> bool;
+}
+
+/// An interface that transforms Plonk circuits to polynomial used by
+/// Plonk-based SNARKs.
+pub trait Arithmetization<F: FftField>: Circuit<F> {
+    /// The required SRS size for the circuit.
+    fn srs_size(&self) -> Result<usize, CircuitError>;
+
+    /// Get the size of the evaluation domain for arithmetization (after circuit
+    /// has been finalized).
+    fn eval_domain_size(&self) -> Result<usize, CircuitError>;
+
+    /// Compute and return selector polynomials.
+    /// Return an error if the circuit has not been finalized yet.
+    fn compute_selector_polynomials(&self) -> Result<Vec<DensePolynomial<F>>, CircuitError>;
+
+    /// Compute and return extended permutation polynomials.
+    /// Return an error if the circuit has not been finalized yet.
+    fn compute_extended_permutation_polynomials(
+        &self,
+    ) -> Result<Vec<DensePolynomial<F>>, CircuitError>;
+
+    /// Compute and return the product polynomial for permutation arguments.
+    /// Return an error if the circuit has not been finalized yet.
+    fn compute_prod_permutation_polynomial(
+        &self,
+        beta: &F,
+        gamma: &F,
+    ) -> Result<DensePolynomial<F>, CircuitError>;
+
+    /// Compute and return the list of wiring witness polynomials.
+    /// Return an error if the circuit has not been finalized yet.
+    fn compute_wire_polynomials(&self) -> Result<Vec<DensePolynomial<F>>, CircuitError>;
+
+    /// Compute and return the public input polynomial.
+    /// Return an error if the circuit has not been finalized yet.
+    /// The IO gates of the circuit are guaranteed to be in the front.
+    fn compute_pub_input_polynomial(&self) -> Result<DensePolynomial<F>, CircuitError>;
+
+    /// Plookup-related methods
+    /// Return default errors if the constraint system does not support lookup
+    /// gates.
+    ///
+    /// Compute and return the polynomial that interpolates the range table
+    /// elements. Return an error if the circuit does not support lookup or
+    /// has not been finalized yet.
+    fn compute_range_table_polynomial(&self) -> Result<DensePolynomial<F>, CircuitError> {
+        Err(CircuitError::LookupUnsupported)
+    }
+
+    /// Compute and return the polynomial that interpolates the key table
+    /// elements. Return an error if the circuit does not support lookup or
+    /// has not been finalized yet.
+    fn compute_key_table_polynomial(&self) -> Result<DensePolynomial<F>, CircuitError> {
+        Err(CircuitError::LookupUnsupported)
+    }
+
+    /// Compute and return the polynomial that interpolates the table domain
+    /// sepration ids. Return an error if the circuit does not support
+    /// lookup or has not been finalized.
+    fn compute_table_dom_sep_polynomial(&self) -> Result<DensePolynomial<F>, CircuitError> {
+        Err(CircuitError::LookupUnsupported)
+    }
+
+    /// Compute and return the polynomial that interpolates the lookup domain
+    /// sepration selectors for the lookup gates. Return an error if the
+    /// circuit does not support lookup or has not been finalized.
+    fn compute_q_dom_sep_polynomial(&self) -> Result<DensePolynomial<F>, CircuitError> {
+        Err(CircuitError::LookupUnsupported)
+    }
+
+    /// Compute and return the combined lookup table vector given random
+    /// challenge `tau`.
+    fn compute_merged_lookup_table(&self, _tau: F) -> Result<Vec<F>, CircuitError> {
+        Err(CircuitError::LookupUnsupported)
+    }
+
+    /// Compute the sorted concatenation of the (merged) lookup table and the
+    /// witness values to be checked in lookup gates. Return the sorted
+    /// vector and 2 polynomials that interpolate the vector. Return an
+    /// error if the circuit does not support lookup or has not been
+    /// finalized yet.
+    fn compute_lookup_sorted_vec_polynomials(
+        &self,
+        _tau: F,
+        _lookup_table: &[F],
+    ) -> Result<SortedLookupVecAndPolys<F>, CircuitError> {
+        Err(CircuitError::LookupUnsupported)
+    }
+
+    /// Compute and return the product polynomial for Plookup arguments.
+    /// `beta` and `gamma` are random challenges, `sorted_vec` is the sorted
+    /// concatenation of the lookup table and the lookup witnesses.
+    /// Return an error if the circuit does not support lookup or
+    /// has not been finalized yet.
+    fn compute_lookup_prod_polynomial(
+        &self,
+        _tau: &F,
+        _beta: &F,
+        _gamma: &F,
+        _lookup_table: &[F],
+        _sorted_vec: &[F],
+    ) -> Result<DensePolynomial<F>, CircuitError> {
+        Err(CircuitError::LookupUnsupported)
+    }
+}

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -6,5 +6,5 @@ export RUSTFLAGS="-C overflow-checks=on"
 
 cargo +nightly test --release -p jf-utils -- -Zunstable-options --report-time
 cargo +nightly test --release -p mpc-plonk --lib --bins --all-features -- -Zunstable-options --report-time
-cargo +nightly test --release -p jf-primitives --features test-srs -- -Zunstable-options --report-time # enable test-srs feature for gen_srs_for_testing
-cargo +nightly test --release -p mpc-relation -- -Zunstable-options --report-time
+cargo +nightly test --release -p jf-primitives --all-features -- -Zunstable-options --report-time # enable test-srs feature for gen_srs_for_testing
+cargo +nightly test --release -p mpc-relation --all-features -- -Zunstable-options --report-time


### PR DESCRIPTION
### Purpose
This PR mostly moves code around and fixes imports to separate out `relation` traits into their own module. These traits are expanding to support multiprover shared functionality, so it is helpful to give them their own module.

### Testing
- Unit tests pass