### PR TITLE
relation: traits: Generalize the `Circuit` trait to work for all provers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ repository = "https://github.com/EspressoSystems/jellyfish"
 
 [workspace.dependencies]
 itertools = { version = "0.10.1", default-features = false }
+ark-mpc = { git = "https://github.com/renegade-fi/ark-mpc" }

--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = { workspace = true }
 [dependencies]
 ark-ec = "0.4.0"
 ark-ff = { version = "0.4.0", features = ["asm"] }
-ark-mpc = { git = "https://github.com/renegade-fi/ark-mpc.git" }
+ark-mpc = { workspace = true }
 ark-poly = "0.4.2"
 ark-serialize = "0.4.0"
 ark-std = { version = "0.4.0", default-features = false }

--- a/plonk/src/multiprover/gadgets/arithmetic.rs
+++ b/plonk/src/multiprover/gadgets/arithmetic.rs
@@ -11,7 +11,7 @@ use mpc_relation::{
     Variable,
 };
 
-use crate::multiprover::proof_system::{MpcCircuit, MpcPlonkCircuit};
+use crate::multiprover::proof_system::MpcPlonkCircuit;
 
 use super::scalar;
 

--- a/plonk/src/multiprover/gadgets/mod.rs
+++ b/plonk/src/multiprover/gadgets/mod.rs
@@ -1,26 +1,8 @@
 //! Defines commonly used gadgets directly on the circuit type
 //!
 //! These gadgets are largely copied from the single-prover implementation
-use core::cmp::Ordering;
-
-use mpc_relation::errors::CircuitError;
 
 pub mod arithmetic;
-
-// Helper function to find the next multiple of `divisor` for `current` value
-pub(crate) fn next_multiple(current: usize, divisor: usize) -> Result<usize, CircuitError> {
-    if divisor == 0 || divisor == 1 {
-        return Err(CircuitError::InternalError(
-            "can only be a multiple of divisor >= 2".to_string(),
-        ));
-    }
-
-    match current.cmp(&divisor) {
-        Ordering::Equal => Ok(current),
-        Ordering::Less => Ok(divisor),
-        Ordering::Greater => Ok((current / divisor + 1) * divisor),
-    }
-}
 
 /// A shorthand notation for wrapping a `CurveGroup`'s scalar field in
 /// an MPC fabric `Scalar`

--- a/plonk/src/multiprover/proof_system/prover.rs
+++ b/plonk/src/multiprover/proof_system/prover.rs
@@ -825,7 +825,7 @@ pub(crate) mod test {
     use rand::thread_rng;
 
     use crate::{
-        multiprover::proof_system::{MpcChallenges, MpcCircuit, MpcOracles, MpcPlonkCircuit},
+        multiprover::proof_system::{MpcChallenges, MpcOracles, MpcPlonkCircuit},
         proof_system::{
             prover::Prover,
             structs::{Challenges, Oracles, ProofEvaluations, ProvingKey, VerifyingKey},

--- a/plonk/src/multiprover/proof_system/snark.rs
+++ b/plonk/src/multiprover/proof_system/snark.rs
@@ -10,8 +10,12 @@ use ark_ec::{
     pairing::Pairing,
     short_weierstrass::{Affine, SWCurveConfig},
 };
-use ark_mpc::{algebra::AuthenticatedScalarResult, MpcFabric};
+use ark_mpc::{
+    algebra::{AuthenticatedScalarResult, Scalar},
+    MpcFabric,
+};
 use itertools::Itertools;
+use mpc_relation::traits::Circuit;
 
 use crate::{
     errors::{PlonkError, SnarkError},
@@ -42,6 +46,11 @@ impl<P: SWCurveConfig<BaseField = E::BaseField>, E: Pairing<G1Affine = Affine<P>
     ) -> Result<CollaborativeProof<E>, PlonkError>
     where
         C: MpcArithmetization<E::G1>,
+        C: Circuit<
+            E::ScalarField,
+            Wire = AuthenticatedScalarResult<E::G1>,
+            Constant = Scalar<E::G1>,
+        >,
     {
         let domain_size = circuit.eval_domain_size()?;
         let num_wire_types = circuit.num_wire_types();
@@ -199,7 +208,7 @@ mod tests {
         errors::PlonkError,
         multiprover::proof_system::{
             test::{setup_snark, test_multiprover_circuit, test_singleprover_circuit, TestGroup},
-            MpcCircuit, MpcPlonkCircuit,
+            MpcPlonkCircuit,
         },
         proof_system::{snark::test::gen_circuit_for_test, PlonkKzgSnark},
         transcript::SolidityTranscript,

--- a/plonk/src/proof_system/mod.rs
+++ b/plonk/src/proof_system/mod.rs
@@ -88,6 +88,7 @@ pub trait UniversalSNARK<E: Pairing> {
     ) -> Result<Self::Proof, Self::Error>
     where
         C: Arithmetization<E::ScalarField>,
+        C: Circuit<E::ScalarField, Wire = E::ScalarField, Constant = E::ScalarField>,
         R: CryptoRng + RngCore,
         T: PlonkTranscript<E::BaseField>;
 

--- a/plonk/src/proof_system/snark.rs
+++ b/plonk/src/proof_system/snark.rs
@@ -67,6 +67,7 @@ where
     ) -> Result<BatchProof<E>, PlonkError>
     where
         C: Arithmetization<E::ScalarField>,
+        C: Circuit<E::ScalarField, Wire = E::ScalarField, Constant = E::ScalarField>,
         R: CryptoRng + RngCore,
         T: PlonkTranscript<F>,
     {
@@ -177,6 +178,7 @@ where
     >
     where
         C: Arithmetization<E::ScalarField>,
+        C: Circuit<E::ScalarField, Wire = E::ScalarField, Constant = E::ScalarField>,
         R: CryptoRng + RngCore,
         T: PlonkTranscript<F>,
     {
@@ -603,6 +605,7 @@ where
     ) -> Result<Self::Proof, Self::Error>
     where
         C: Arithmetization<E::ScalarField>,
+        C: Circuit<E::ScalarField, Wire = E::ScalarField, Constant = E::ScalarField>,
         R: CryptoRng + RngCore,
         T: PlonkTranscript<F>,
     {

--- a/relation/Cargo.toml
+++ b/relation/Cargo.toml
@@ -14,7 +14,7 @@ ark-bn254 = "0.4.0"
 ark-bw6-761 = "0.4.0"
 ark-ec = "0.4.0"
 ark-ff = { version = "0.4.0", features = ["asm"] }
-ark-mpc = { git = "https://github.com/renegade-fi/ark-mpc.git" }
+ark-mpc = { workspace = true }
 ark-poly = "0.4.0"
 ark-serialize = "0.4.0"
 ark-std = { version = "0.4.0", default-features = false }

--- a/relation/src/gadgets/ecc/glv.rs
+++ b/relation/src/gadgets/ecc/glv.rs
@@ -480,7 +480,7 @@ where
     //  (c) tmp1 = 0        <- implied by tmp = 2^128 * tmp2
     //  (d) tmp2 < 2^128
     //  (e) tmp = tmp1 + 2^128 tmp2
-    circuit.mul_constant_gate(tmp2_var, two_to_128, tmp_var)?;
+    circuit.mul_constant_gate(tmp2_var, &two_to_128, tmp_var)?;
     circuit.enforce_in_range(tmp2_var, 128)?;
 
     // ============================================

--- a/relation/src/gadgets/ultraplonk/range.rs
+++ b/relation/src/gadgets/ultraplonk/range.rs
@@ -88,7 +88,6 @@ fn decompose_le<F: PrimeField>(val: F, len: usize, range_bit_len: usize) -> Vec<
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::traits::ConstraintSystem;
     use ark_bls12_377::Fq as Fq377;
     use ark_ed_on_bls12_377::Fq as FqEd377;
     use ark_ed_on_bls12_381::Fq as FqEd381;

--- a/relation/src/traits.rs
+++ b/relation/src/traits.rs
@@ -1,19 +1,89 @@
 //! Defines traits for expressing a Plonk relation
 
-use core::ops::{Add, Mul, Neg, Sub};
-
-use ark_ff::{FftField, Field};
+use ark_ff::{FftField, Field, One, Zero};
+use ark_mpc::algebra::FieldWrapper;
 use ark_poly::univariate::DensePolynomial;
+use core::{
+    fmt::Debug,
+    iter::Sum,
+    ops::{Add, Mul, Neg, Sub},
+};
 
 use crate::{
     constants::{GATE_WIDTH, N_MUL_SELECTORS},
     errors::CircuitError,
-    gates::Gate,
+    gates::{
+        AdditionGate, BoolGate, ConstantAdditionGate, ConstantGate, ConstantMultiplicationGate,
+        EqualityGate, Gate, LinCombGate, MulAddGate, MultiplicationGate, MuxGate, SubtractionGate,
+    },
     next_multiple, BoolVar, SortedLookupVecAndPolys, Variable,
 };
 
-/// An interface for Plonk constraint systems.
-pub trait Circuit<F: Field>: ConstraintSystem<F> {
+/// A shorthand for converting a value to a constant in the circuit
+macro_rules! felt {
+    ($x:expr) => {
+        Self::Constant::from_field(&$x)
+    };
+}
+
+/// A shorthand for converting a slice of values to a slice of constants in the
+/// circuit
+macro_rules! felts {
+    ($x:expr) => {
+        $x.iter()
+            .map(|x| Self::Constant::from_field(x))
+            .collect::<Vec<_>>()
+    };
+}
+
+/// An interface to add gates to a circuit that generalizes across wiring
+/// implementations
+///
+/// Effectively abstracts the variable-centric gate interface
+///
+/// The generic `W` corresponds to the witness type assigned to wires, this
+/// allows both single and multiprover implementations to make use of the
+/// underlying default impls
+///
+/// The generic `C` corresponds to the constant type used to represent public
+/// values in the circuit
+///
+/// The generic `F` corresponds to the field that the circuit is over, this
+/// type is stored in gates and used to construct selectors
+pub trait Circuit<F: Field> {
+    /// The type that wires take in the circuit
+    type Wire: 'static
+        + Debug
+        + Sized
+        + Clone
+        + Add<Self::Wire, Output = Self::Wire>
+        + Sub<Self::Wire, Output = Self::Wire>
+        + Mul<Self::Wire, Output = Self::Wire>
+        + Neg<Output = Self::Wire>
+        + Sum;
+
+    /// The type that constants take in the circuit
+    type Constant: FieldWrapper<F>
+        + Copy
+        + One
+        + Zero
+        + Mul<Self::Wire, Output = Self::Wire>
+        + Add<Self::Wire, Output = Self::Wire>
+        + Sub<Self::Wire, Output = Self::Wire>
+        + Neg<Output = Self::Constant>;
+
+    // ---------------------
+    // | Circuitry Methods |
+    // ---------------------
+
+    // --- Metadata --- //
+
+    /// Return a default variable with value zero.
+    fn zero(&self) -> Variable;
+
+    /// Return a default variable with value one.
+    fn one(&self) -> Variable;
+
     /// The number of constraints.
     fn num_gates(&self) -> usize;
 
@@ -29,55 +99,71 @@ pub trait Circuit<F: Field>: ConstraintSystem<F> {
     fn num_wire_types(&self) -> usize;
 
     /// The list of public input values.
-    fn public_input(&self) -> Result<Vec<F>, CircuitError>;
+    fn public_input(&self) -> Result<Vec<Self::Wire>, CircuitError>;
+
+    /// Return the witness value of variable `idx`.
+    /// Return error if the input variable is invalid.
+    fn witness(&self, idx: Variable) -> Result<Self::Wire, CircuitError>;
 
     /// Check circuit satisfiability against a public input.
-    fn check_circuit_satisfiability(&self, pub_input: &[F]) -> Result<(), CircuitError>;
+    fn check_circuit_satisfiability(&self, pub_input: &[Self::Wire]) -> Result<(), CircuitError>;
+
+    /// Plookup-related methods.
+    /// Return true if the circuit support lookup gates.
+    fn support_lookup(&self) -> bool;
+
+    // --- Variable Allocation --- //
+
+    /// Check a variable before entering it into a constraint
+    fn check_var(&self, var: Variable) -> Result<(), CircuitError>;
+
+    /// Check a set of variables before entering them into a constraint
+    fn check_vars(&self, vars: &[Variable]) -> Result<(), CircuitError> {
+        for var in vars.iter().copied() {
+            self.check_var(var)?;
+        }
+
+        Ok(())
+    }
 
     /// Add a constant variable to the circuit; return the index of the
     /// variable.
     fn create_constant_variable(&mut self, val: F) -> Result<Variable, CircuitError>;
 
     /// Add a variable to the circuit; return the index of the variable.
-    fn create_variable(&mut self, val: F) -> Result<Variable, CircuitError>;
+    fn create_variable(&mut self, val: Self::Wire) -> Result<Variable, CircuitError>;
 
     /// Add a bool variable to the circuit; return the index of the variable.
-    fn create_boolean_variable(&mut self, val: bool) -> Result<BoolVar, CircuitError> {
-        let val_scalar = if val { F::one() } else { F::zero() };
-        let var = self.create_variable(val_scalar)?;
+    fn create_boolean_variable<T: Into<Self::Wire>>(
+        &mut self,
+        val: T,
+    ) -> Result<BoolVar, CircuitError> {
+        let var = self.create_variable(val.into())?;
         self.enforce_bool(var)?;
         Ok(BoolVar(var))
     }
 
     /// Add a public input variable; return the index of the variable.
-    fn create_public_variable(&mut self, val: F) -> Result<Variable, CircuitError>;
+    fn create_public_variable(&mut self, val: Self::Wire) -> Result<Variable, CircuitError> {
+        let var = self.create_variable(val)?;
+        self.set_variable_public(var)?;
+        Ok(var)
+    }
 
     /// Add a public bool variable to the circuit; return the index of the
     /// variable.
-    fn create_public_boolean_variable(&mut self, val: bool) -> Result<BoolVar, CircuitError> {
-        let val_scalar = if val { F::one() } else { F::zero() };
-        let var = self.create_public_variable(val_scalar)?;
+    fn create_public_boolean_variable<T: Into<Self::Wire>>(
+        &mut self,
+        val: T,
+    ) -> Result<BoolVar, CircuitError> {
+        let var = self.create_public_variable(val.into())?;
         Ok(BoolVar(var))
     }
 
     /// Set a variable to a public variable
     fn set_variable_public(&mut self, var: Variable) -> Result<(), CircuitError>;
 
-    /// Return the witness value of variable `idx`.
-    /// Return error if the input variable is invalid.
-    fn witness(&self, idx: Variable) -> Result<F, CircuitError>;
-}
-
-/// An interface to add gates to a circuit that generalizes across wiring
-/// implementations
-///
-/// Effectively abstracts the variable-centric gate interface
-pub trait ConstraintSystem<F: Field> {
-    /// Return a default variable with value zero.
-    fn zero(&self) -> Variable;
-
-    /// Return a default variable with value one.
-    fn one(&self) -> Variable;
+    // --- Gate Allocation --- //
 
     /// Insert a gate into the constraint system
     fn insert_gate(
@@ -86,9 +172,17 @@ pub trait ConstraintSystem<F: Field> {
         gate: Box<dyn Gate<F>>,
     ) -> Result<(), CircuitError>;
 
-    // -----------
-    // | Boolean |
-    // -----------
+    /// Pad the circuit with n dummy gates
+    fn pad_gates(&mut self, n: usize) {
+        let wire_vars = &[self.zero(), self.zero(), 0, 0, 0];
+        for _ in 0..n {
+            self.insert_gate(wire_vars, Box::new(EqualityGate)).unwrap();
+        }
+    }
+
+    // ----------------
+    // | Boolean Vars |
+    // ----------------
 
     /// Return a default variable with value `false` (namely zero).
     fn false_var(&self) -> BoolVar {
@@ -100,70 +194,161 @@ pub trait ConstraintSystem<F: Field> {
         BoolVar::new_unchecked(self.one())
     }
 
-    // --------------
-    // | Arithmetic |
-    // --------------
+    // --------------------
+    // | Arithmetic Gates |
+    // --------------------
 
     /// Constrain variable `c` to the addition of `a` and `b`.
     /// Return error if the input variables are invalid.
-    fn add_gate(&mut self, a: Variable, b: Variable, c: Variable) -> Result<(), CircuitError>;
+    fn add_gate(&mut self, a: Variable, b: Variable, c: Variable) -> Result<(), CircuitError> {
+        self.check_var(a)?;
+        self.check_var(b)?;
+        self.check_var(c)?;
+
+        let wire_vars = &[a, b, 0, 0, c];
+        self.insert_gate(wire_vars, Box::new(AdditionGate))?;
+        Ok(())
+    }
 
     /// Obtain a variable representing an addition.
     /// Return the index of the variable.
     /// Return error if the input variables are invalid.
-    fn add(&mut self, a: Variable, b: Variable) -> Result<Variable, CircuitError>;
+    fn add(&mut self, a: Variable, b: Variable) -> Result<Variable, CircuitError> {
+        self.check_var(a)?;
+        self.check_var(b)?;
+        let val = self.witness(a)? + self.witness(b)?;
+        let c = self.create_variable(val)?;
+        self.add_gate(a, b, c)?;
+        Ok(c)
+    }
 
     /// Constrain variable `c` to the subtraction of `a` and `b`.
     /// Return error if the input variables are invalid.
-    fn sub_gate(&mut self, a: Variable, b: Variable, c: Variable) -> Result<(), CircuitError>;
+    fn sub_gate(&mut self, a: Variable, b: Variable, c: Variable) -> Result<(), CircuitError> {
+        self.check_var(a)?;
+        self.check_var(b)?;
+        self.check_var(c)?;
+
+        let wire_vars = &[a, b, 0, 0, c];
+        self.insert_gate(wire_vars, Box::new(SubtractionGate))?;
+        Ok(())
+    }
 
     /// Obtain a variable representing a subtraction.
     /// Return the index of the variable.
     /// Return error if the input variables are invalid.
-    fn sub(&mut self, a: Variable, b: Variable) -> Result<Variable, CircuitError>;
+    fn sub(&mut self, a: Variable, b: Variable) -> Result<Variable, CircuitError> {
+        self.check_var(a)?;
+        self.check_var(b)?;
+        let val = self.witness(a)? - self.witness(b)?;
+        let c = self.create_variable(val)?;
+        self.sub_gate(a, b, c)?;
+        Ok(c)
+    }
 
     /// Constrain variable `c` to the multiplication of `a` and `b`.
     /// Return error if the input variables are invalid.
-    fn mul_gate(&mut self, a: Variable, b: Variable, c: Variable) -> Result<(), CircuitError>;
+    fn mul_gate(&mut self, a: Variable, b: Variable, c: Variable) -> Result<(), CircuitError> {
+        self.check_var(a)?;
+        self.check_var(b)?;
+        self.check_var(c)?;
 
-    /// Obtain a variable representing a multiplication.
-    /// Return the index of the variable.
-    /// Return error if the input variables are invalid.
-    fn mul(&mut self, a: Variable, b: Variable) -> Result<Variable, CircuitError>;
+        let wire_vars = &[a, b, 0, 0, c];
+        self.insert_gate(wire_vars, Box::new(MultiplicationGate))?;
+        Ok(())
+    }
 
-    /// Constrain a linear combination gate:
-    /// q1 * a + q2 * b + q3 * c + q4 * d  = y
+    /// Create a variable representation of the output of `a * b`
+    fn mul(&mut self, a: Variable, b: Variable) -> Result<Variable, CircuitError> {
+        self.check_var(a)?;
+        self.check_var(b)?;
+        let val = self.witness(a)? * self.witness(b)?;
+        let c = self.create_variable(val)?;
+        self.mul_gate(a, b, c)?;
+        Ok(c)
+    }
+
+    /// Constrain variable `c` to the linear combination of `a`, `b`, `c`, `d`
     fn lc_gate(
         &mut self,
         wires: &[Variable; GATE_WIDTH + 1],
         coeffs: &[F; GATE_WIDTH],
-    ) -> Result<(), CircuitError>;
+    ) -> Result<(), CircuitError> {
+        self.check_vars(wires)?;
 
-    /// Obtain a variable representing a linear combination.
-    /// Return error if variables are invalid.
+        let wire_vars = [wires[0], wires[1], wires[2], wires[3], wires[4]];
+        self.insert_gate(&wire_vars, Box::new(LinCombGate { coeffs: *coeffs }))?;
+
+        Ok(())
+    }
+
+    /// Create a variable `c` representing a linear combination of `a`, `b`,
+    /// `c`, `d`
     fn lc(
         &mut self,
         wires_in: &[Variable; GATE_WIDTH],
         coeffs: &[F; GATE_WIDTH],
-    ) -> Result<Variable, CircuitError>;
+    ) -> Result<Variable, CircuitError> {
+        self.check_vars(wires_in)?;
 
-    /// Constrain a mul-addition gate:
-    /// q_muls\[0\] * wires\[0\] *  wires\[1\] +  q_muls\[1\] * wires\[2\] *
-    /// wires\[3\] = wires\[4\]
+        let vals_in: Vec<Self::Wire> = wires_in
+            .iter()
+            .map(|&var| self.witness(var))
+            .collect::<Result<Vec<_>, CircuitError>>()?;
+
+        // calculate y as the linear combination of coeffs and vals_in
+        let y_val = vals_in
+            .iter()
+            .zip(coeffs.iter())
+            .map(|(val, coeff)| felt!(coeff) * val.clone())
+            .sum();
+        let y = self.create_variable(y_val)?;
+
+        let wires = [wires_in[0], wires_in[1], wires_in[2], wires_in[3], y];
+        self.lc_gate(&wires, coeffs)?;
+        Ok(y)
+    }
+
+    /// Constrain variable `wires[4]` to the mul-addition of `q_mul[0] * a * b +
+    /// q_mul[1] * c * d`
     fn mul_add_gate(
         &mut self,
         wires: &[Variable; GATE_WIDTH + 1],
         q_muls: &[F; N_MUL_SELECTORS],
-    ) -> Result<(), CircuitError>;
+    ) -> Result<(), CircuitError> {
+        self.check_vars(wires)?;
 
-    /// Obtain a variable representing `q12 * a * b + q34 * c * d`,
-    /// where `a, b, c, d` are input wires, and `q12`, `q34` are selectors.
-    /// Return error if variables are invalid.
+        let wire_vars = [wires[0], wires[1], wires[2], wires[3], wires[4]];
+        self.insert_gate(&wire_vars, Box::new(MulAddGate { coeffs: *q_muls }))?;
+
+        Ok(())
+    }
+
+    /// Create a variable `y` representing the mul-addition of `q_mul[0] * a *
+    /// b + q_mul[1] * c * d`
     fn mul_add(
         &mut self,
         wires_in: &[Variable; GATE_WIDTH],
         q_muls: &[F; N_MUL_SELECTORS],
-    ) -> Result<Variable, CircuitError>;
+    ) -> Result<Variable, CircuitError> {
+        // Fetch the witness elements for the input wires
+        self.check_vars(wires_in)?;
+        let [wire0, wire1, wire2, wire3]: [Self::Wire; 4] = wires_in
+            .iter()
+            .map(|&var| self.witness(var))
+            .collect::<Result<Vec<_>, CircuitError>>()?
+            .try_into()
+            .expect("incorrect number of wires");
+
+        // Calculate y as the mul-addition of coeffs and vals_in
+        let coeffs = felts!(q_muls);
+        let y_val = coeffs[0] * wire0 * wire1 + coeffs[1] * wire2 * wire3;
+        let y = self.create_variable(y_val)?;
+
+        let wires = [wires_in[0], wires_in[1], wires_in[2], wires_in[3], y];
+        self.mul_add_gate(&wires, q_muls)?;
+        Ok(y)
+    }
 
     /// Add two values with coefficients `a` and `b`, i.e. `a * x + b * y`
     fn add_with_coeffs(
@@ -190,9 +375,59 @@ pub trait ConstraintSystem<F: Field> {
         self.mul_add(&[a, b, zero, zero], &[*c, F::zero()])
     }
 
-    /// Obtain a variable representing the sum of a list of variables.
-    /// Return error if variables are invalid.
-    fn sum(&mut self, elems: &[Variable]) -> Result<Variable, CircuitError>;
+    /// Create a variable representation of the sum of a slice of variables
+    fn sum(&mut self, elems: &[Variable]) -> Result<Variable, CircuitError> {
+        if elems.is_empty() {
+            return Err(CircuitError::ParameterError(
+                "Sum over an empty slice of variables is undefined".to_string(),
+            ));
+        }
+        self.check_vars(elems)?;
+
+        // Construct the output wire's assignment
+        let sum_val: Self::Wire = elems
+            .iter()
+            .map(|&elem| self.witness(elem))
+            .collect::<Result<Vec<_>, CircuitError>>()?
+            .iter()
+            .cloned()
+            .sum();
+        let sum = self.create_variable(sum_val)?;
+
+        // Pad to ("next multiple of 3" + 1) in length
+        let mut padded: Vec<Variable> = elems.to_vec();
+        let rate = GATE_WIDTH - 1; // rate at which each lc add
+        let padded_len = next_multiple(elems.len() - 1, rate)? + 1;
+        padded.resize(padded_len, self.zero());
+
+        // z_0 = = x_0
+        // z_i = z_i-1 + x_3i-2 + x_3i-1 + x_3i
+        let coeffs = [F::one(); GATE_WIDTH];
+        let mut accum = padded[0];
+        for i in 1..padded_len / rate {
+            accum = self.lc(
+                &[
+                    accum,
+                    padded[rate * i - 2],
+                    padded[rate * i - 1],
+                    padded[rate * i],
+                ],
+                &coeffs,
+            )?;
+        }
+
+        // Final round
+        let wires = [
+            accum,
+            padded[padded_len - 3],
+            padded[padded_len - 2],
+            padded[padded_len - 1],
+            sum,
+        ];
+        self.lc_gate(&wires, &coeffs)?;
+
+        Ok(sum)
+    }
 
     /// Sum a vector of variables with given coefficients
     fn lc_sum(&mut self, elems: &[Variable], coeffs: &[F]) -> Result<Variable, CircuitError> {
@@ -221,40 +456,89 @@ pub trait ConstraintSystem<F: Field> {
         self.sum(&partials)
     }
 
-    /// Constrain variable `y` to the addition of `a` and `c`, where `c` is a
-    /// constant value Return error if the input variables are invalid.
-    fn add_constant_gate(&mut self, x: Variable, c: F, y: Variable) -> Result<(), CircuitError>;
+    /// Constrain variable `y` to the addition of `x` and `c`
+    fn add_constant_gate(&mut self, x: Variable, c: &F, y: Variable) -> Result<(), CircuitError> {
+        self.check_var(x)?;
+        self.check_var(y)?;
 
-    /// Obtains a variable representing an addition with a constant value
-    /// Return error if the input variable is invalid
-    fn add_constant(&mut self, input_var: Variable, elem: &F) -> Result<Variable, CircuitError>;
+        let wire_vars = &[x, self.one(), 0, 0, y];
+        self.insert_gate(wire_vars, Box::new(ConstantAdditionGate(*c)))?;
+        Ok(())
+    }
 
-    /// Constrain variable `y` to the product of `a` and `c`, where `c` is a
-    /// constant value Return error if the input variables are invalid.
-    fn mul_constant_gate(&mut self, x: Variable, c: F, y: Variable) -> Result<(), CircuitError>;
+    /// Create a variable `y` representing the addition of `x` and `c`
+    fn add_constant(&mut self, x: Variable, c: &F) -> Result<Variable, CircuitError> {
+        self.check_var(x)?;
 
-    /// Obtains a variable representing a multiplication with a constant value
-    /// Return error if the input variable is invalid
-    fn mul_constant(&mut self, input_var: Variable, elem: &F) -> Result<Variable, CircuitError>;
+        let input_val = self.witness(x).unwrap();
+        let output_val = felt!(c) + input_val;
+        let output_var = self.create_variable(output_val).unwrap();
 
-    /// Takes the input to the fifth power
+        self.add_constant_gate(x, c, output_var)?;
+
+        Ok(output_var)
+    }
+
+    /// Constrain variable `y` to the multiplication of `x` and `c`
+    fn mul_constant_gate(&mut self, x: Variable, c: &F, y: Variable) -> Result<(), CircuitError> {
+        self.check_var(x)?;
+        self.check_var(y)?;
+
+        let wire_vars = &[x, 0, 0, 0, y];
+        self.insert_gate(wire_vars, Box::new(ConstantMultiplicationGate(*c)))?;
+        Ok(())
+    }
+
+    /// Create a variable `y` representing the multiplication of `x` and `c`
+    fn mul_constant(&mut self, input_var: Variable, elem: &F) -> Result<Variable, CircuitError> {
+        self.check_var(input_var)?;
+
+        let input_val = self.witness(input_var).unwrap();
+        let output_val = felt!(elem) * input_val;
+        let output_var = self.create_variable(output_val).unwrap();
+
+        self.mul_constant_gate(input_var, elem, output_var)?;
+
+        Ok(output_var)
+    }
+
+    /// Returns the fifth power of a variable
     fn pow5(&mut self, x: Variable) -> Result<Variable, CircuitError>;
 
     // ---------------
     // | Logic Gates |
     // ---------------
 
-    /// Constrains variable `c` to be `if sel { a } else b`
+    /// Constrains variable `c` to be `if sel { a } else { b }`
     fn mux_gate(
         &mut self,
         sel: BoolVar,
         a: Variable,
         b: Variable,
         c: Variable,
-    ) -> Result<(), CircuitError>;
+    ) -> Result<(), CircuitError> {
+        self.check_var(a)?;
+        self.check_var(b)?;
+        self.check_var(c)?;
+        self.check_var(sel.into())?;
 
-    /// Create a variable representation of `if sel { a } else { b }`
-    fn mux(&mut self, sel: BoolVar, a: Variable, b: Variable) -> Result<Variable, CircuitError>;
+        let wire_vars = &[sel.into(), a, sel.into(), b, c];
+        self.insert_gate(wire_vars, Box::new(MuxGate))
+    }
+
+    /// Returns a variable representing `if sel { a } else { b }`
+    fn mux(&mut self, sel: BoolVar, a: Variable, b: Variable) -> Result<Variable, CircuitError> {
+        let sel_eval = self.witness(sel.into())?;
+        let a_eval = self.witness(a)?;
+        let b_eval = self.witness(b)?;
+
+        let one = Self::Constant::one();
+        let res = sel_eval.clone() * a_eval + (one - sel_eval) * b_eval;
+        let res_var = self.create_variable(res)?;
+
+        self.mux_gate(sel, a, b, res_var)?;
+        Ok(res_var)
+    }
 
     // ---------------
     // | Constraints |
@@ -264,22 +548,34 @@ pub trait ConstraintSystem<F: Field> {
     ///
     /// Constrain a variable to a constant.
     /// Return error if `var` is an invalid variable.
-    fn enforce_constant(&mut self, var: Variable, constant: F) -> Result<(), CircuitError>;
+    fn enforce_constant(&mut self, var: Variable, constant: F) -> Result<(), CircuitError> {
+        self.check_var(var)?;
+
+        let wire_vars = &[0, 0, 0, 0, var];
+        self.insert_gate(wire_vars, Box::new(ConstantGate(constant)))?;
+        Ok(())
+    }
 
     /// Constrain a variable to a bool.
     /// Return error if the input is invalid.
-    fn enforce_bool(&mut self, a: Variable) -> Result<(), CircuitError>;
+    fn enforce_bool(&mut self, a: Variable) -> Result<(), CircuitError> {
+        self.check_var(a)?;
+
+        let wire_vars = &[a, a, 0, 0, a];
+        self.insert_gate(wire_vars, Box::new(BoolGate))?;
+        Ok(())
+    }
 
     /// Constrain two variables to have the same value.
     /// Return error if the input variables are invalid.
-    fn enforce_equal(&mut self, a: Variable, b: Variable) -> Result<(), CircuitError>;
+    fn enforce_equal(&mut self, a: Variable, b: Variable) -> Result<(), CircuitError> {
+        self.check_var(a)?;
+        self.check_var(b)?;
 
-    /// Pad the circuit with n dummy gates
-    fn pad_gates(&mut self, n: usize);
-
-    /// Plookup-related methods.
-    /// Return true if the circuit support lookup gates.
-    fn support_lookup(&self) -> bool;
+        let wire_vars = &[a, b, 0, 0, 0];
+        self.insert_gate(wire_vars, Box::new(EqualityGate))?;
+        Ok(())
+    }
 }
 
 /// An interface that transforms Plonk circuits to polynomial used by
@@ -338,14 +634,14 @@ pub trait Arithmetization<F: FftField>: Circuit<F> {
     }
 
     /// Compute and return the polynomial that interpolates the table domain
-    /// sepration ids. Return an error if the circuit does not support
+    /// separation ids. Return an error if the circuit does not support
     /// lookup or has not been finalized.
     fn compute_table_dom_sep_polynomial(&self) -> Result<DensePolynomial<F>, CircuitError> {
         Err(CircuitError::LookupUnsupported)
     }
 
     /// Compute and return the polynomial that interpolates the lookup domain
-    /// sepration selectors for the lookup gates. Return an error if the
+    /// separation selectors for the lookup gates. Return an error if the
     /// circuit does not support lookup or has not been finalized.
     fn compute_q_dom_sep_polynomial(&self) -> Result<DensePolynomial<F>, CircuitError> {
         Err(CircuitError::LookupUnsupported)


### PR DESCRIPTION
### Purpose
This PR refactors the traits in the constraint system in two ways:
1. The `ConstraintSystem` trait, which previously captured shared functionality between proof systems, regardless of wiring types, was removed and merged into `Circuit`
2. `Circuit` is generalized to work over any choice of wiring type: i.e. over a `Field` as well as an `AuthenticatedScalarResult` for MPC provers. 

This allows us to implement shared functionality as default implementations on the `Circuit` trait, so that provers may inherit more of the advanced circuitry without reimplementing.

The motivation comes from the previously increasing disparity and overhead of implementing new shared functionality, and bugs that came from disparate implementations.

### Testing
- Unit tests pass