### PR TITLE
plonk: multiprover: proof-system: Use batch ops in third round

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ Cargo.lock
 .pre-commit-config.yaml
 .vscode
 
+# Profiling
+**/flamegraph.svg
+
 # Test coverage (grcov)
 default.profraw
 /.pre-commit-config.yaml

--- a/plonk/benches/collaborative_proof.rs
+++ b/plonk/benches/collaborative_proof.rs
@@ -112,13 +112,8 @@ async fn multiprover_prove(pk: &ProvingKey<TestCurve>) -> Duration {
             )
             .unwrap();
 
-            black_box(
-                MultiproverPlonkKzgSnark::prove(&circuit, &pk, fabric)
-                    .unwrap()
-                    .open_authenticated()
-                    .await
-                    .unwrap(),
-            );
+            let proof = MultiproverPlonkKzgSnark::prove(&circuit, &pk, fabric).unwrap();
+            black_box(proof.open_authenticated().await.unwrap());
 
             start.elapsed()
         }

--- a/plonk/src/multiprover/gadgets/arithmetic.rs
+++ b/plonk/src/multiprover/gadgets/arithmetic.rs
@@ -1,7 +1,7 @@
 //! Defines arithmetic gadgets for use in circuits
 
 use ark_ec::CurveGroup;
-use ark_ff::One;
+use ark_ff::{FftField, One};
 use ark_mpc::algebra::Scalar;
 use mpc_relation::{
     constants::{GATE_WIDTH, N_MUL_SELECTORS},
@@ -15,7 +15,10 @@ use crate::multiprover::proof_system::MpcPlonkCircuit;
 
 use super::scalar;
 
-impl<C: CurveGroup> MpcPlonkCircuit<C> {
+impl<C: CurveGroup> MpcPlonkCircuit<C>
+where
+    C::ScalarField: FftField + Unpin,
+{
     /// Arithmetic gates
     ///
     /// Quadratic polynomial gate: q1 * a + q2 * b + q3 * c + q4 * d + q12 * a *

--- a/plonk/src/multiprover/proof_system/constraint_system.rs
+++ b/plonk/src/multiprover/proof_system/constraint_system.rs
@@ -83,7 +83,7 @@ where
 #[allow(unused)]
 pub struct MpcPlonkCircuit<C: CurveGroup>
 where
-    C::ScalarField: FftField,
+    C::ScalarField: FftField + Unpin,
 {
     /// The number of variables
     num_vars: usize,
@@ -127,7 +127,7 @@ where
 
 impl<C: CurveGroup> MpcPlonkCircuit<C>
 where
-    C::ScalarField: FftField,
+    C::ScalarField: FftField + Unpin,
 {
     /// Constructor
     pub fn new(fabric: MpcFabric<C>) -> Self {
@@ -199,7 +199,10 @@ where
 }
 
 /// Private helper methods
-impl<C: CurveGroup> MpcPlonkCircuit<C> {
+impl<C: CurveGroup> MpcPlonkCircuit<C>
+where
+    C::ScalarField: FftField + Unpin,
+{
     /// Whether the circuit is finalized
     fn is_finalized(&self) -> bool {
         self.eval_domain.size() != 1
@@ -480,7 +483,10 @@ impl<C: CurveGroup> MpcPlonkCircuit<C> {
 }
 
 #[async_trait]
-impl<C: CurveGroup> Circuit<C::ScalarField> for MpcPlonkCircuit<C> {
+impl<C: CurveGroup> Circuit<C::ScalarField> for MpcPlonkCircuit<C>
+where
+    C::ScalarField: Unpin,
+{
     type Wire = AuthenticatedScalarResult<C>;
     type Constant = Scalar<C>;
 
@@ -653,7 +659,10 @@ impl<C: CurveGroup> Circuit<C::ScalarField> for MpcPlonkCircuit<C> {
 }
 
 /// Private permutation related methods
-impl<C: CurveGroup> MpcPlonkCircuit<C> {
+impl<C: CurveGroup> MpcPlonkCircuit<C>
+where
+    C::ScalarField: FftField + Unpin,
+{
     /// Copy constraints: precompute the extended permutation over circuit
     /// wires. Refer to Sec 5.2 and Sec 8.1 of https://eprint.iacr.org/2019/953.pdf for more details.
     #[inline]
@@ -709,7 +718,10 @@ impl<C: CurveGroup> MpcPlonkCircuit<C> {
 }
 
 /// Finalization
-impl<C: CurveGroup> MpcPlonkCircuit<C> {
+impl<C: CurveGroup> MpcPlonkCircuit<C>
+where
+    C::ScalarField: FftField + Unpin,
+{
     /// Finalize the setup of the circuit before arithmetization.
     pub fn finalize_for_arithmetization(&mut self) -> Result<(), CircuitError> {
         if self.is_finalized() {
@@ -726,7 +738,10 @@ impl<C: CurveGroup> MpcPlonkCircuit<C> {
     }
 }
 
-impl<C: CurveGroup> MpcArithmetization<C> for MpcPlonkCircuit<C> {
+impl<C: CurveGroup> MpcArithmetization<C> for MpcPlonkCircuit<C>
+where
+    C::ScalarField: Unpin,
+{
     fn srs_size(&self) -> Result<usize, CircuitError> {
         Ok(self.eval_domain_size()? + 2)
     }

--- a/plonk/src/multiprover/proof_system/snark.rs
+++ b/plonk/src/multiprover/proof_system/snark.rs
@@ -217,7 +217,7 @@ pub mod test_helpers {
     pub type TestScalar = <TestCurve as Pairing>::ScalarField;
 
     /// The max degree of the circuits used for testing
-    pub const MAX_DEGREE_TESTING: usize = 1024;
+    pub const MAX_DEGREE_TESTING: usize = 65536;
 
     /// Setup commitment keys, proving and verification keys for the snark
     pub fn setup_snark<C: Arithmetization<TestScalar>>(


### PR DESCRIPTION
### Purpose
This PR refactors the Plonk third round implementation to use batch gates instead of individual gates. This greatly reduces the work queue of the executor under the hood.

### Testing
- Unit tests pass