### PR TITLE
plonk: multiprover: constraint-system: Use batch ops in second round

### DIFF
--- a/plonk/src/multiprover/proof_system/prover.rs
+++ b/plonk/src/multiprover/proof_system/prover.rs
@@ -876,7 +876,7 @@ fn quotient_polynomial_degree(domain_size: usize, num_wire_types: usize) -> usiz
 }
 
 /// Take the element-wise product of a set of vectors
-fn element_wise_product<C: CurveGroup>(
+pub fn element_wise_product<C: CurveGroup>(
     vectors: &[Vec<AuthenticatedScalarResult<C>>],
 ) -> Vec<AuthenticatedScalarResult<C>> {
     assert!(!vectors.is_empty(), "must have at least one vector");


### PR DESCRIPTION
### Purpose
This PR refactors the second round plonk implementation to use batched ops for computing the permutation polynomial. This greatly reduces the load on the executor.

### Testing
- All unit tests pass