### PR TITLE
benches: collaborative-proof: Fine-tune executor hints

### DIFF
--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -82,8 +82,9 @@ std = [
 ]
 test_apis = ["ark-bn254", "rand", "ark-mpc/test_helpers"]
 parallel = [
-    "ark-ff/parallel",
     "ark-ec/parallel",
+    "ark-ff/parallel",
+    "ark-mpc/multithreaded_executor",
     "ark-poly/parallel",
     "ark-std/parallel",
     "jf-utils/parallel",


### PR DESCRIPTION
### Purpose
This PR adds fine-tuned executor hints to the collaborative proof benchmark to get a more realistic figure after optimization.

### Testing
- All unit tests pass