### PR TITLE
plonk: proof-system: structs: Mark commit_key as public

### DIFF
--- a/plonk/src/proof_system/structs.rs
+++ b/plonk/src/proof_system/structs.rs
@@ -551,7 +551,7 @@ pub struct ProvingKey<E: Pairing> {
     pub(crate) selectors: Vec<DensePolynomial<E::ScalarField>>,
 
     // KZG PCS committing key.
-    pub(crate) commit_key: CommitKey<E>,
+    pub commit_key: CommitKey<E>,
 
     /// The verifying key. It is used by prover to initialize transcripts.
     pub vk: VerifyingKey<E>,


### PR DESCRIPTION
### Purpose
This PR makes the `commit_key` field public on the `ProvingKey` struct. This is used to generate link proofs prover side.