### PR TITLE
plonk: proof-system: proof-linking: Impl serialization for LinkingProof

### DIFF
--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -49,6 +49,7 @@ ark-ed-on-bn254 = "0.4.0"
 criterion = { version = "0.5", features = ["async", "async_tokio"] }
 hex = "^0.4.3"
 lazy_static = "1.4"
+serde_json = "1.0"
 tokio = "1.33"
 
 # Benchmarks


### PR DESCRIPTION
### Purpose
This PR implements `Serialize` and `Deserialize` for `LinkingProof` structs.

### Testing
- Unit tests pass